### PR TITLE
Improve highlighting queries, add markdown injection in documentation

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -172,7 +172,7 @@ module.exports = grammar({
       seq("import", field("s", $.static_string)),
       $.type_array,
       seq(field("t1", $.applicative), field("t2", $.record_operand)),
-      // We don't explicitly have the the following three rules. Instead we
+      // We don't explicitly have the following three rules. Instead we
       // match generically on builtin functions.
       // This is different from the lalrpop grammar. See NOTE[builtin].
       //seq($.u_op, $.record_operand),
@@ -221,7 +221,7 @@ module.exports = grammar({
       $.bool,
       $.str_chunks,
       $.ident,
-      // DIFERENT from lalrpop grammar. See NOTE[builtin].
+      // DIFFERENT from lalrpop grammar. See NOTE[builtin].
       $.builtin,
       $.uni_record,
       $.enum_tag,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,4 +1,5 @@
 (comment) @comment @spell
+(annot_atom doc: (static_string) @spell)
 
 [
   "forall"
@@ -22,13 +23,13 @@
 ; BUILTIN Constants
 (bool) @boolean
 "null" @constant.builtin
+(enum_tag) @constant
 
 (num_literal) @number
 
 (infix_op) @operator
 
 (type_atom) @type
-(enum_tag) @variable
 
 (chunk_literal_single) @string
 (chunk_literal_multi) @string
@@ -40,6 +41,18 @@
  "(" ")"
  "[|" "|]"
 ] @punctuation.bracket
+
+[
+ ","
+ "."
+ ":"
+ "="
+ "|"
+ "->"
+ "+"
+ "-"
+ "*"
+] @punctuation.delimiter
 
 (multstr_start) @punctuation.bracket
 (multstr_end) @punctuation.bracket
@@ -56,6 +69,12 @@
   )
 )
 
+; application where the head terms is an identifier: function arg1 arg2 arg3
 (applicative t1:
-  (applicative (record_operand) @function)
+  (applicative (record_operand (atom (ident))) @function)
+)
+
+; application where the head terms is a record field path: foo.bar.function arg1 arg2 arg3
+(applicative t1:
+  (applicative (record_operand (record_operation_chain)) @function)
 )

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,3 @@
+(annot_atom doc: (static_string)
+            @injection.content
+            (#set! injection.language "markdown"))


### PR DESCRIPTION
This PR improves the highlight queries. In particular, function highlighting was too permissive, as it colored anything to the left of an application to be a function, meaning that in `(foo bar) baz`, `(foo bar)` was highlighted as a function, but it's not.

This PR also adds spellchecking for the documentation metadata, turns enum tags to constants, and adds an injection to specify that what's inside the doc is `markdown`. Note that I couldn't test this latter feature, as I've had a lot of trouble getting neovim to pick the injections. It might require more configuration, but I've spent too much time on this already...