### PR TITLE
Add not_exported metadata

### DIFF
--- a/corpus/metadata.txt
+++ b/corpus/metadata.txt
@@ -220,3 +220,53 @@ metadata prio
                                 (chunk_literal_single
                                   (str_literal))))))))))))))))))
 
+
+================================================================================
+metadata not_exported
+================================================================================
+
+{
+  "not_exported"
+    | not_exported
+    = 5,
+  exported
+    = 6
+}
+
+--------------------------------------------------------------------------------
+
+(term
+  (uni_term
+    (infix_expr
+      (applicative
+        (record_operand
+          (atom
+            (uni_record
+              (record_field
+                (field_path
+                  (field_path_elem
+                    (str_chunks
+                      (str_chunks_single
+                        (chunk_literal_single
+                          (str_literal))))))
+                (annot
+                  (annot_atom))
+                (term
+                  (uni_term
+                    (infix_expr
+                      (applicative
+                        (record_operand
+                          (atom
+                            (num_literal))))))))
+              (record_last_field
+                (record_field
+                  (field_path
+                    (field_path_elem
+                      (ident)))
+                  (term
+                    (uni_term
+                      (infix_expr
+                        (applicative
+                          (record_operand
+                            (atom
+                              (num_literal))))))))))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -63,7 +63,7 @@ module.exports = grammar({
     ////////////////////////////
     // LEXER RELATED RULES (lexer.rs)
     ////////////////////////////
-    keyword: _ => token(/if|then|else|forall|in|let|match|null|true|false|fun|import|merge|default|doc|force|optional|priority/),
+    keyword: _ => token(/if|then|else|forall|in|let|rec|match|null|true|false|fun|import|merge|default|doc|force|optional|priority|not_exported/),
 
     num_literal: _ => /[0-9]*\.?[0-9]+/,
 
@@ -94,6 +94,7 @@ module.exports = grammar({
       seq("|", "doc", field("doc", $.static_string)),
       seq("|", "rec", "force"),
       seq("|", "rec", "default"),
+      seq("|", "not_exported"),
       seq(":", field("ty", $.types)),
     ),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -8,6 +8,10 @@
   "default"
   "doc"
   "rec"
+  "optional"
+  "priority"
+  "force"
+  "not_exported"
 ] @keyword
 
 "fun" @keyword.function

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10,7 +10,7 @@
       "type": "TOKEN",
       "content": {
         "type": "PATTERN",
-        "value": "if|then|else|forall|in|let|match|null|true|false|fun|import|merge|default|doc|force|optional|priority"
+        "value": "if|then|else|forall|in|let|rec|match|null|true|false|fun|import|merge|default|doc|force|optional|priority|not_exported"
       }
     },
     "num_literal": {
@@ -161,6 +161,19 @@
             {
               "type": "STRING",
               "value": "default"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "|"
+            },
+            {
+              "type": "STRING",
+              "value": "not_exported"
             }
           ]
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1603,6 +1603,10 @@
     "named": true
   },
   {
+    "type": "not_exported",
+    "named": false
+  },
+  {
     "type": "null",
     "named": false
   },

--- a/src/parser.c
+++ b/src/parser.c
@@ -8,9 +8,9 @@
 #define LANGUAGE_VERSION 14
 #define STATE_COUNT 1040
 #define LARGE_STATE_COUNT 8
-#define SYMBOL_COUNT 148
+#define SYMBOL_COUNT 149
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 78
+#define TOKEN_COUNT 79
 #define EXTERNAL_TOKEN_COUNT 8
 #define FIELD_COUNT 34
 #define MAX_ALIAS_SEQUENCE_LENGTH 7
@@ -29,141 +29,142 @@ enum {
   anon_sym_priority = 10,
   anon_sym_doc = 11,
   anon_sym_rec = 12,
-  anon_sym_COLON = 13,
-  anon_sym_let = 14,
-  anon_sym_EQ = 15,
-  anon_sym_in = 16,
-  anon_sym_fun = 17,
-  anon_sym_EQ_GT = 18,
-  anon_sym_match = 19,
-  anon_sym_LBRACE = 20,
-  anon_sym_COMMA = 21,
-  anon_sym_RBRACE = 22,
-  anon_sym_if = 23,
-  anon_sym_then = 24,
-  anon_sym_else = 25,
-  anon_sym_forall = 26,
-  anon_sym_DOT = 27,
-  anon_sym_import = 28,
-  anon_sym_Array = 29,
-  anon_sym_Dyn = 30,
-  anon_sym_SEMI = 31,
-  anon_sym_LPAREN = 32,
-  anon_sym_RPAREN = 33,
-  anon_sym_null = 34,
-  anon_sym_LBRACK = 35,
-  anon_sym_RBRACK = 36,
-  anon_sym_DOT_DOT = 37,
-  anon_sym_AT = 38,
-  anon_sym_QMARK = 39,
-  anon_sym_true = 40,
-  anon_sym_false = 41,
-  anon_sym_PERCENT = 42,
-  sym_double_quote = 43,
-  sym_str_literal = 44,
-  sym_mult_str_literal = 45,
-  sym_str_esc_char = 46,
-  anon_sym__ = 47,
-  anon_sym_PLUS_PLUS = 48,
-  anon_sym_STAR = 49,
-  anon_sym_SLASH = 50,
-  anon_sym_PLUS = 51,
-  anon_sym_DASH = 52,
-  anon_sym_BANG = 53,
-  anon_sym_AMP = 54,
-  anon_sym_PIPE_GT = 55,
-  anon_sym_LT = 56,
-  anon_sym_LT_EQ = 57,
-  anon_sym_GT = 58,
-  anon_sym_GT_EQ = 59,
-  anon_sym_EQ_EQ = 60,
-  anon_sym_BANG_EQ = 61,
-  anon_sym_AMP_AMP = 62,
-  anon_sym_PIPE_PIPE = 63,
-  anon_sym_DASH_GT = 64,
-  anon_sym_Num = 65,
-  anon_sym_Bool = 66,
-  anon_sym_Str = 67,
-  anon_sym_LBRACK_PIPE = 68,
-  anon_sym_PIPE_RBRACK = 69,
-  sym_multstr_start = 70,
-  sym_multstr_end = 71,
-  sym__str_start = 72,
-  sym__str_end = 73,
-  sym_interpolation_start = 74,
-  sym_interpolation_end = 75,
-  sym_quoted_enum_tag_start = 76,
-  sym_comment = 77,
-  sym_term = 78,
-  sym_annot_atom = 79,
-  sym_annot = 80,
-  sym_types = 81,
-  sym_uni_term = 82,
-  sym_let_expr = 83,
-  sym_let_in_block = 84,
-  sym_fun_expr = 85,
-  sym_match_expr = 86,
-  sym_ite_expr = 87,
-  sym_annotated_infix_expr = 88,
-  sym_forall = 89,
-  sym_applicative = 90,
-  sym_type_array = 91,
-  sym_record_operand = 92,
-  sym_record_operation_chain = 93,
-  sym_row_tail = 94,
-  sym_uni_record = 95,
-  sym_atom = 96,
-  sym_record_field = 97,
-  sym_record_last_field = 98,
-  sym_field_path = 99,
-  sym_field_path_elem = 100,
-  sym_last_match = 101,
-  sym_pattern = 102,
-  sym_destruct = 103,
-  sym_match = 104,
-  sym_default_annot = 105,
-  sym_bool = 106,
-  sym_str_chunks = 107,
-  sym_str_chunks_single = 108,
-  sym_str_chunks_multi = 109,
-  sym_chunk_expr = 110,
-  sym_static_string = 111,
-  sym_quoted_enum_tag = 112,
-  sym_enum_tag = 113,
-  sym_chunk_literal_single = 114,
-  sym_chunk_literal_multi = 115,
-  sym_percent = 116,
-  sym_builtin = 117,
-  sym_match_case = 118,
-  sym_infix_b_op_2 = 119,
-  sym_infix_b_op_3 = 120,
-  sym_infix_b_op_4 = 121,
-  sym_infix_u_op_5 = 122,
-  sym_infix_b_op_6 = 123,
-  sym_infix_b_op_7 = 124,
-  sym_infix_b_op_8 = 125,
-  sym_infix_lazy_b_op_9 = 126,
-  sym_infix_lazy_b_op_10 = 127,
-  sym_infix_b_op = 128,
-  sym_infix_u_op_or_lazy_b_op = 129,
-  sym_infix_op = 130,
-  sym_curried_op = 131,
-  sym_infix_expr = 132,
-  sym_type_builtin = 133,
-  sym_type_atom = 134,
-  aux_sym_annot_repeat1 = 135,
-  aux_sym_fun_expr_repeat1 = 136,
-  aux_sym_match_expr_repeat1 = 137,
-  aux_sym_forall_repeat1 = 138,
-  aux_sym_uni_record_repeat1 = 139,
-  aux_sym_atom_repeat1 = 140,
-  aux_sym_field_path_repeat1 = 141,
-  aux_sym_destruct_repeat1 = 142,
-  aux_sym_str_chunks_single_repeat1 = 143,
-  aux_sym_str_chunks_multi_repeat1 = 144,
-  aux_sym_static_string_repeat1 = 145,
-  aux_sym_static_string_repeat2 = 146,
-  aux_sym_type_atom_repeat1 = 147,
+  anon_sym_not_exported = 13,
+  anon_sym_COLON = 14,
+  anon_sym_let = 15,
+  anon_sym_EQ = 16,
+  anon_sym_in = 17,
+  anon_sym_fun = 18,
+  anon_sym_EQ_GT = 19,
+  anon_sym_match = 20,
+  anon_sym_LBRACE = 21,
+  anon_sym_COMMA = 22,
+  anon_sym_RBRACE = 23,
+  anon_sym_if = 24,
+  anon_sym_then = 25,
+  anon_sym_else = 26,
+  anon_sym_forall = 27,
+  anon_sym_DOT = 28,
+  anon_sym_import = 29,
+  anon_sym_Array = 30,
+  anon_sym_Dyn = 31,
+  anon_sym_SEMI = 32,
+  anon_sym_LPAREN = 33,
+  anon_sym_RPAREN = 34,
+  anon_sym_null = 35,
+  anon_sym_LBRACK = 36,
+  anon_sym_RBRACK = 37,
+  anon_sym_DOT_DOT = 38,
+  anon_sym_AT = 39,
+  anon_sym_QMARK = 40,
+  anon_sym_true = 41,
+  anon_sym_false = 42,
+  anon_sym_PERCENT = 43,
+  sym_double_quote = 44,
+  sym_str_literal = 45,
+  sym_mult_str_literal = 46,
+  sym_str_esc_char = 47,
+  anon_sym__ = 48,
+  anon_sym_PLUS_PLUS = 49,
+  anon_sym_STAR = 50,
+  anon_sym_SLASH = 51,
+  anon_sym_PLUS = 52,
+  anon_sym_DASH = 53,
+  anon_sym_BANG = 54,
+  anon_sym_AMP = 55,
+  anon_sym_PIPE_GT = 56,
+  anon_sym_LT = 57,
+  anon_sym_LT_EQ = 58,
+  anon_sym_GT = 59,
+  anon_sym_GT_EQ = 60,
+  anon_sym_EQ_EQ = 61,
+  anon_sym_BANG_EQ = 62,
+  anon_sym_AMP_AMP = 63,
+  anon_sym_PIPE_PIPE = 64,
+  anon_sym_DASH_GT = 65,
+  anon_sym_Num = 66,
+  anon_sym_Bool = 67,
+  anon_sym_Str = 68,
+  anon_sym_LBRACK_PIPE = 69,
+  anon_sym_PIPE_RBRACK = 70,
+  sym_multstr_start = 71,
+  sym_multstr_end = 72,
+  sym__str_start = 73,
+  sym__str_end = 74,
+  sym_interpolation_start = 75,
+  sym_interpolation_end = 76,
+  sym_quoted_enum_tag_start = 77,
+  sym_comment = 78,
+  sym_term = 79,
+  sym_annot_atom = 80,
+  sym_annot = 81,
+  sym_types = 82,
+  sym_uni_term = 83,
+  sym_let_expr = 84,
+  sym_let_in_block = 85,
+  sym_fun_expr = 86,
+  sym_match_expr = 87,
+  sym_ite_expr = 88,
+  sym_annotated_infix_expr = 89,
+  sym_forall = 90,
+  sym_applicative = 91,
+  sym_type_array = 92,
+  sym_record_operand = 93,
+  sym_record_operation_chain = 94,
+  sym_row_tail = 95,
+  sym_uni_record = 96,
+  sym_atom = 97,
+  sym_record_field = 98,
+  sym_record_last_field = 99,
+  sym_field_path = 100,
+  sym_field_path_elem = 101,
+  sym_last_match = 102,
+  sym_pattern = 103,
+  sym_destruct = 104,
+  sym_match = 105,
+  sym_default_annot = 106,
+  sym_bool = 107,
+  sym_str_chunks = 108,
+  sym_str_chunks_single = 109,
+  sym_str_chunks_multi = 110,
+  sym_chunk_expr = 111,
+  sym_static_string = 112,
+  sym_quoted_enum_tag = 113,
+  sym_enum_tag = 114,
+  sym_chunk_literal_single = 115,
+  sym_chunk_literal_multi = 116,
+  sym_percent = 117,
+  sym_builtin = 118,
+  sym_match_case = 119,
+  sym_infix_b_op_2 = 120,
+  sym_infix_b_op_3 = 121,
+  sym_infix_b_op_4 = 122,
+  sym_infix_u_op_5 = 123,
+  sym_infix_b_op_6 = 124,
+  sym_infix_b_op_7 = 125,
+  sym_infix_b_op_8 = 126,
+  sym_infix_lazy_b_op_9 = 127,
+  sym_infix_lazy_b_op_10 = 128,
+  sym_infix_b_op = 129,
+  sym_infix_u_op_or_lazy_b_op = 130,
+  sym_infix_op = 131,
+  sym_curried_op = 132,
+  sym_infix_expr = 133,
+  sym_type_builtin = 134,
+  sym_type_atom = 135,
+  aux_sym_annot_repeat1 = 136,
+  aux_sym_fun_expr_repeat1 = 137,
+  aux_sym_match_expr_repeat1 = 138,
+  aux_sym_forall_repeat1 = 139,
+  aux_sym_uni_record_repeat1 = 140,
+  aux_sym_atom_repeat1 = 141,
+  aux_sym_field_path_repeat1 = 142,
+  aux_sym_destruct_repeat1 = 143,
+  aux_sym_str_chunks_single_repeat1 = 144,
+  aux_sym_str_chunks_multi_repeat1 = 145,
+  aux_sym_static_string_repeat1 = 146,
+  aux_sym_static_string_repeat2 = 147,
+  aux_sym_type_atom_repeat1 = 148,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -180,6 +181,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_priority] = "priority",
   [anon_sym_doc] = "doc",
   [anon_sym_rec] = "rec",
+  [anon_sym_not_exported] = "not_exported",
   [anon_sym_COLON] = ":",
   [anon_sym_let] = "let",
   [anon_sym_EQ] = "=",
@@ -331,6 +333,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_priority] = anon_sym_priority,
   [anon_sym_doc] = anon_sym_doc,
   [anon_sym_rec] = anon_sym_rec,
+  [anon_sym_not_exported] = anon_sym_not_exported,
   [anon_sym_COLON] = anon_sym_COLON,
   [anon_sym_let] = anon_sym_let,
   [anon_sym_EQ] = anon_sym_EQ,
@@ -518,6 +521,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_rec] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_not_exported] = {
     .visible = true,
     .named = false,
   },
@@ -1468,17 +1475,17 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [66] = 36,
   [67] = 52,
   [68] = 52,
-  [69] = 8,
+  [69] = 69,
   [70] = 8,
-  [71] = 8,
-  [72] = 8,
+  [71] = 69,
+  [72] = 69,
   [73] = 8,
-  [74] = 74,
-  [75] = 74,
-  [76] = 74,
-  [77] = 74,
-  [78] = 74,
-  [79] = 74,
+  [74] = 69,
+  [75] = 69,
+  [76] = 69,
+  [77] = 8,
+  [78] = 8,
+  [79] = 8,
   [80] = 80,
   [81] = 81,
   [82] = 82,
@@ -2446,822 +2453,837 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(65);
-      if (lookahead == '!') ADVANCE(171);
-      if (lookahead == '"') ADVANCE(158);
-      if (lookahead == '%') ADVANCE(157);
-      if (lookahead == '&') ADVANCE(172);
-      if (lookahead == '(') ADVANCE(150);
-      if (lookahead == ')') ADVANCE(151);
-      if (lookahead == '*') ADVANCE(167);
-      if (lookahead == '+') ADVANCE(169);
-      if (lookahead == ',') ADVANCE(143);
-      if (lookahead == '-') ADVANCE(170);
-      if (lookahead == '.') ADVANCE(146);
-      if (lookahead == '/') ADVANCE(168);
-      if (lookahead == ':') ADVANCE(137);
-      if (lookahead == ';') ADVANCE(149);
-      if (lookahead == '<') ADVANCE(174);
-      if (lookahead == '=') ADVANCE(139);
-      if (lookahead == '>') ADVANCE(176);
-      if (lookahead == '?') ADVANCE(156);
-      if (lookahead == '@') ADVANCE(155);
-      if (lookahead == 'A') ADVANCE(116);
-      if (lookahead == 'B') ADVANCE(102);
-      if (lookahead == 'D') ADVANCE(127);
-      if (lookahead == 'N') ADVANCE(123);
-      if (lookahead == 'S') ADVANCE(121);
-      if (lookahead == '[') ADVANCE(152);
-      if (lookahead == '\\') ADVANCE(61);
-      if (lookahead == ']') ADVANCE(153);
-      if (lookahead == '_') ADVANCE(165);
+      if (eof) ADVANCE(75);
+      if (lookahead == '!') ADVANCE(189);
+      if (lookahead == '"') ADVANCE(176);
+      if (lookahead == '%') ADVANCE(175);
+      if (lookahead == '&') ADVANCE(190);
+      if (lookahead == '(') ADVANCE(168);
+      if (lookahead == ')') ADVANCE(169);
+      if (lookahead == '*') ADVANCE(185);
+      if (lookahead == '+') ADVANCE(187);
+      if (lookahead == ',') ADVANCE(161);
+      if (lookahead == '-') ADVANCE(188);
+      if (lookahead == '.') ADVANCE(164);
+      if (lookahead == '/') ADVANCE(186);
+      if (lookahead == ':') ADVANCE(155);
+      if (lookahead == ';') ADVANCE(167);
+      if (lookahead == '<') ADVANCE(192);
+      if (lookahead == '=') ADVANCE(157);
+      if (lookahead == '>') ADVANCE(194);
+      if (lookahead == '?') ADVANCE(174);
+      if (lookahead == '@') ADVANCE(173);
+      if (lookahead == 'A') ADVANCE(132);
+      if (lookahead == 'B') ADVANCE(115);
+      if (lookahead == 'D') ADVANCE(146);
+      if (lookahead == 'N') ADVANCE(142);
+      if (lookahead == 'S') ADVANCE(139);
+      if (lookahead == '[') ADVANCE(170);
+      if (lookahead == '\\') ADVANCE(72);
+      if (lookahead == ']') ADVANCE(171);
+      if (lookahead == '_') ADVANCE(183);
       if (lookahead == '`') ADVANCE(11);
-      if (lookahead == 'd') ADVANCE(81);
-      if (lookahead == 'e') ADVANCE(93);
-      if (lookahead == 'f') ADVANCE(72);
-      if (lookahead == 'i') ADVANCE(130);
-      if (lookahead == 'l') ADVANCE(83);
-      if (lookahead == 'm') ADVANCE(75);
-      if (lookahead == 'n') ADVANCE(124);
-      if (lookahead == 'o') ADVANCE(108);
-      if (lookahead == 'p') ADVANCE(109);
-      if (lookahead == 'r') ADVANCE(85);
-      if (lookahead == 't') ADVANCE(89);
-      if (lookahead == '{') ADVANCE(142);
-      if (lookahead == '|') ADVANCE(134);
-      if (lookahead == '}') ADVANCE(144);
+      if (lookahead == 'd') ADVANCE(92);
+      if (lookahead == 'e') ADVANCE(106);
+      if (lookahead == 'f') ADVANCE(83);
+      if (lookahead == 'i') ADVANCE(149);
+      if (lookahead == 'l') ADVANCE(97);
+      if (lookahead == 'm') ADVANCE(87);
+      if (lookahead == 'n') ADVANCE(118);
+      if (lookahead == 'o') ADVANCE(123);
+      if (lookahead == 'p') ADVANCE(125);
+      if (lookahead == 'r') ADVANCE(93);
+      if (lookahead == 't') ADVANCE(102);
+      if (lookahead == '{') ADVANCE(160);
+      if (lookahead == '|') ADVANCE(153);
+      if (lookahead == '}') ADVANCE(162);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(68);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(78);
       if (('C' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(158);
-      if (lookahead == '%') ADVANCE(157);
-      if (lookahead == '\\') ADVANCE(161);
+      if (lookahead == '"') ADVANCE(176);
+      if (lookahead == '%') ADVANCE(175);
+      if (lookahead == '\\') ADVANCE(179);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(162);
-      if (lookahead != 0) ADVANCE(163);
+          lookahead == ' ') ADVANCE(180);
+      if (lookahead != 0) ADVANCE(181);
       END_STATE();
     case 2:
-      if (lookahead == '%') ADVANCE(157);
-      if (lookahead == '\\') ADVANCE(61);
+      if (lookahead == '%') ADVANCE(175);
+      if (lookahead == '\\') ADVANCE(72);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(159);
+          lookahead == ' ') ADVANCE(177);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(160);
+          lookahead != '"') ADVANCE(178);
       END_STATE();
     case 3:
-      if (lookahead == ')') ADVANCE(151);
-      if (lookahead == ',') ADVANCE(143);
+      if (lookahead == ')') ADVANCE(169);
+      if (lookahead == ',') ADVANCE(161);
       if (lookahead == '-') ADVANCE(6);
       if (lookahead == '.') ADVANCE(5);
-      if (lookahead == ':') ADVANCE(137);
-      if (lookahead == ';') ADVANCE(149);
-      if (lookahead == '=') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(155);
-      if (lookahead == '_') ADVANCE(165);
-      if (lookahead == '{') ADVANCE(142);
-      if (lookahead == '|') ADVANCE(133);
-      if (lookahead == '}') ADVANCE(144);
+      if (lookahead == ':') ADVANCE(155);
+      if (lookahead == ';') ADVANCE(167);
+      if (lookahead == '=') ADVANCE(158);
+      if (lookahead == '@') ADVANCE(173);
+      if (lookahead == '_') ADVANCE(183);
+      if (lookahead == '{') ADVANCE(160);
+      if (lookahead == '|') ADVANCE(152);
+      if (lookahead == '}') ADVANCE(162);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(3)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(70);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(80);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 4:
-      if (lookahead == ',') ADVANCE(143);
-      if (lookahead == '.') ADVANCE(145);
-      if (lookahead == ';') ADVANCE(149);
+      if (lookahead == ',') ADVANCE(161);
+      if (lookahead == '.') ADVANCE(163);
+      if (lookahead == ';') ADVANCE(167);
       if (lookahead == '=') ADVANCE(8);
-      if (lookahead == '_') ADVANCE(59);
+      if (lookahead == '_') ADVANCE(70);
       if (lookahead == '`') ADVANCE(11);
-      if (lookahead == '{') ADVANCE(142);
+      if (lookahead == '{') ADVANCE(160);
       if (lookahead == '|') ADVANCE(10);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(4)
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 5:
-      if (lookahead == '.') ADVANCE(154);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(71);
+      if (lookahead == '.') ADVANCE(172);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(81);
       END_STATE();
     case 6:
-      if (lookahead == '.') ADVANCE(58);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(70);
+      if (lookahead == '.') ADVANCE(69);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(80);
       END_STATE();
     case 7:
-      if (lookahead == '=') ADVANCE(179);
+      if (lookahead == '=') ADVANCE(197);
       END_STATE();
     case 8:
-      if (lookahead == '>') ADVANCE(141);
+      if (lookahead == '>') ADVANCE(159);
       END_STATE();
     case 9:
-      if (lookahead == 'D') ADVANCE(127);
-      if (lookahead == '_') ADVANCE(59);
+      if (lookahead == 'D') ADVANCE(146);
+      if (lookahead == '_') ADVANCE(70);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(9)
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 10:
-      if (lookahead == ']') ADVANCE(187);
+      if (lookahead == ']') ADVANCE(205);
       END_STATE();
     case 11:
-      if (lookahead == '_') ADVANCE(60);
+      if (lookahead == '_') ADVANCE(71);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
       END_STATE();
     case 12:
-      if (lookahead == '_') ADVANCE(59);
-      if (lookahead == 'r') ADVANCE(85);
-      if (lookahead == '{') ADVANCE(142);
+      if (lookahead == '_') ADVANCE(70);
+      if (lookahead == 'd') ADVANCE(92);
+      if (lookahead == 'e') ADVANCE(106);
+      if (lookahead == 'f') ADVANCE(83);
+      if (lookahead == 'i') ADVANCE(149);
+      if (lookahead == 'l') ADVANCE(97);
+      if (lookahead == 'm') ADVANCE(87);
+      if (lookahead == 'n') ADVANCE(118);
+      if (lookahead == 'o') ADVANCE(123);
+      if (lookahead == 'p') ADVANCE(125);
+      if (lookahead == 'r') ADVANCE(93);
+      if (lookahead == 't') ADVANCE(102);
+      if (lookahead == '{') ADVANCE(160);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(12)
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 13:
-      if (lookahead == 'a') ADVANCE(31);
-      if (lookahead == 'o') ADVANCE(44);
-      if (lookahead == 'u') ADVANCE(35);
+      if (lookahead == '_') ADVANCE(27);
       END_STATE();
     case 14:
-      if (lookahead == 'a') ADVANCE(34);
-      if (lookahead == 'c') ADVANCE(22);
+      if (lookahead == 'a') ADVANCE(36);
+      if (lookahead == 'o') ADVANCE(52);
+      if (lookahead == 'u') ADVANCE(40);
       END_STATE();
     case 15:
-      if (lookahead == 'a') ADVANCE(50);
-      if (lookahead == 'e') ADVANCE(45);
+      if (lookahead == 'a') ADVANCE(39);
+      if (lookahead == 'c') ADVANCE(25);
       END_STATE();
     case 16:
-      if (lookahead == 'a') ADVANCE(32);
+      if (lookahead == 'a') ADVANCE(60);
+      if (lookahead == 'e') ADVANCE(53);
       END_STATE();
     case 17:
-      if (lookahead == 'a') ADVANCE(54);
+      if (lookahead == 'a') ADVANCE(63);
       END_STATE();
     case 18:
-      if (lookahead == 'c') ADVANCE(66);
+      if (lookahead == 'a') ADVANCE(37);
       END_STATE();
     case 19:
-      if (lookahead == 'c') ADVANCE(26);
+      if (lookahead == 'c') ADVANCE(76);
       END_STATE();
     case 20:
-      if (lookahead == 'e') ADVANCE(24);
-      if (lookahead == 'o') ADVANCE(18);
+      if (lookahead == 'c') ADVANCE(31);
       END_STATE();
     case 21:
-      if (lookahead == 'e') ADVANCE(35);
+      if (lookahead == 'd') ADVANCE(76);
       END_STATE();
     case 22:
-      if (lookahead == 'e') ADVANCE(66);
+      if (lookahead == 'e') ADVANCE(29);
+      if (lookahead == 'o') ADVANCE(19);
       END_STATE();
     case 23:
-      if (lookahead == 'e') ADVANCE(48);
+      if (lookahead == 'e') ADVANCE(19);
       END_STATE();
     case 24:
-      if (lookahead == 'f') ADVANCE(17);
+      if (lookahead == 'e') ADVANCE(40);
       END_STATE();
     case 25:
-      if (lookahead == 'g') ADVANCE(22);
+      if (lookahead == 'e') ADVANCE(76);
       END_STATE();
     case 26:
-      if (lookahead == 'h') ADVANCE(66);
+      if (lookahead == 'e') ADVANCE(57);
       END_STATE();
     case 27:
-      if (lookahead == 'h') ADVANCE(21);
-      if (lookahead == 'r') ADVANCE(53);
+      if (lookahead == 'e') ADVANCE(65);
       END_STATE();
     case 28:
-      if (lookahead == 'i') ADVANCE(39);
+      if (lookahead == 'e') ADVANCE(21);
       END_STATE();
     case 29:
-      if (lookahead == 'i') ADVANCE(37);
+      if (lookahead == 'f') ADVANCE(17);
       END_STATE();
     case 30:
-      if (lookahead == 'i') ADVANCE(49);
+      if (lookahead == 'g') ADVANCE(25);
       END_STATE();
     case 31:
-      if (lookahead == 'l') ADVANCE(47);
+      if (lookahead == 'h') ADVANCE(76);
       END_STATE();
     case 32:
-      if (lookahead == 'l') ADVANCE(66);
+      if (lookahead == 'h') ADVANCE(24);
+      if (lookahead == 'r') ADVANCE(64);
       END_STATE();
     case 33:
-      if (lookahead == 'l') ADVANCE(48);
+      if (lookahead == 'i') ADVANCE(46);
       END_STATE();
     case 34:
-      if (lookahead == 'l') ADVANCE(32);
+      if (lookahead == 'i') ADVANCE(42);
       END_STATE();
     case 35:
-      if (lookahead == 'n') ADVANCE(66);
+      if (lookahead == 'i') ADVANCE(59);
       END_STATE();
     case 36:
-      if (lookahead == 'n') ADVANCE(16);
+      if (lookahead == 'l') ADVANCE(56);
       END_STATE();
     case 37:
-      if (lookahead == 'o') ADVANCE(36);
+      if (lookahead == 'l') ADVANCE(76);
       END_STATE();
     case 38:
-      if (lookahead == 'o') ADVANCE(42);
+      if (lookahead == 'l') ADVANCE(57);
       END_STATE();
     case 39:
-      if (lookahead == 'o') ADVANCE(46);
+      if (lookahead == 'l') ADVANCE(37);
       END_STATE();
     case 40:
-      if (lookahead == 'p') ADVANCE(38);
+      if (lookahead == 'n') ADVANCE(76);
       END_STATE();
     case 41:
-      if (lookahead == 'p') ADVANCE(51);
+      if (lookahead == 'n') ADVANCE(18);
       END_STATE();
     case 42:
-      if (lookahead == 'r') ADVANCE(48);
+      if (lookahead == 'o') ADVANCE(41);
       END_STATE();
     case 43:
-      if (lookahead == 'r') ADVANCE(28);
+      if (lookahead == 'o') ADVANCE(58);
+      if (lookahead == 'u') ADVANCE(39);
       END_STATE();
     case 44:
-      if (lookahead == 'r') ADVANCE(14);
+      if (lookahead == 'o') ADVANCE(50);
       END_STATE();
     case 45:
-      if (lookahead == 'r') ADVANCE(25);
+      if (lookahead == 'o') ADVANCE(55);
       END_STATE();
     case 46:
-      if (lookahead == 'r') ADVANCE(30);
+      if (lookahead == 'o') ADVANCE(54);
       END_STATE();
     case 47:
-      if (lookahead == 's') ADVANCE(22);
+      if (lookahead == 'p') ADVANCE(44);
       END_STATE();
     case 48:
-      if (lookahead == 't') ADVANCE(66);
+      if (lookahead == 'p') ADVANCE(62);
       END_STATE();
     case 49:
-      if (lookahead == 't') ADVANCE(55);
+      if (lookahead == 'p') ADVANCE(45);
       END_STATE();
     case 50:
-      if (lookahead == 't') ADVANCE(19);
+      if (lookahead == 'r') ADVANCE(57);
       END_STATE();
     case 51:
-      if (lookahead == 't') ADVANCE(29);
+      if (lookahead == 'r') ADVANCE(33);
       END_STATE();
     case 52:
-      if (lookahead == 'u') ADVANCE(34);
+      if (lookahead == 'r') ADVANCE(15);
       END_STATE();
     case 53:
-      if (lookahead == 'u') ADVANCE(22);
+      if (lookahead == 'r') ADVANCE(30);
       END_STATE();
     case 54:
-      if (lookahead == 'u') ADVANCE(33);
+      if (lookahead == 'r') ADVANCE(35);
       END_STATE();
     case 55:
-      if (lookahead == 'y') ADVANCE(66);
+      if (lookahead == 'r') ADVANCE(61);
       END_STATE();
     case 56:
-      if (lookahead == 'f' ||
-          lookahead == 'n') ADVANCE(66);
-      if (lookahead == 'm') ADVANCE(40);
+      if (lookahead == 's') ADVANCE(25);
       END_STATE();
     case 57:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(69);
+      if (lookahead == 't') ADVANCE(76);
       END_STATE();
     case 58:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(71);
+      if (lookahead == 't') ADVANCE(13);
       END_STATE();
     case 59:
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+      if (lookahead == 't') ADVANCE(66);
       END_STATE();
     case 60:
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
+      if (lookahead == 't') ADVANCE(20);
       END_STATE();
     case 61:
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(164);
+      if (lookahead == 't') ADVANCE(28);
       END_STATE();
     case 62:
-      if (eof) ADVANCE(65);
-      if (lookahead == '!') ADVANCE(171);
-      if (lookahead == '%') ADVANCE(157);
-      if (lookahead == '&') ADVANCE(172);
-      if (lookahead == '(') ADVANCE(150);
-      if (lookahead == ')') ADVANCE(151);
-      if (lookahead == '*') ADVANCE(167);
-      if (lookahead == '+') ADVANCE(169);
-      if (lookahead == ',') ADVANCE(143);
-      if (lookahead == '-') ADVANCE(170);
-      if (lookahead == '.') ADVANCE(57);
-      if (lookahead == '/') ADVANCE(168);
-      if (lookahead == ':') ADVANCE(137);
-      if (lookahead == ';') ADVANCE(149);
-      if (lookahead == '<') ADVANCE(174);
-      if (lookahead == '=') ADVANCE(138);
-      if (lookahead == '>') ADVANCE(176);
-      if (lookahead == '?') ADVANCE(156);
-      if (lookahead == '@') ADVANCE(155);
-      if (lookahead == 'A') ADVANCE(116);
-      if (lookahead == 'B') ADVANCE(102);
-      if (lookahead == 'D') ADVANCE(127);
-      if (lookahead == 'N') ADVANCE(123);
-      if (lookahead == 'S') ADVANCE(121);
-      if (lookahead == '[') ADVANCE(152);
-      if (lookahead == ']') ADVANCE(153);
-      if (lookahead == '_') ADVANCE(59);
-      if (lookahead == '`') ADVANCE(11);
-      if (lookahead == 'd') ADVANCE(81);
-      if (lookahead == 'e') ADVANCE(93);
-      if (lookahead == 'f') ADVANCE(72);
-      if (lookahead == 'i') ADVANCE(130);
-      if (lookahead == 'l') ADVANCE(83);
-      if (lookahead == 'm') ADVANCE(75);
-      if (lookahead == 'n') ADVANCE(124);
-      if (lookahead == 'o') ADVANCE(108);
-      if (lookahead == 'p') ADVANCE(109);
-      if (lookahead == 't') ADVANCE(89);
-      if (lookahead == '{') ADVANCE(142);
-      if (lookahead == '|') ADVANCE(135);
-      if (lookahead == '}') ADVANCE(144);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(62)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(68);
-      if (('C' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+      if (lookahead == 't') ADVANCE(34);
       END_STATE();
     case 63:
-      if (eof) ADVANCE(65);
-      if (lookahead == '!') ADVANCE(7);
-      if (lookahead == '%') ADVANCE(157);
-      if (lookahead == '&') ADVANCE(172);
-      if (lookahead == '(') ADVANCE(150);
-      if (lookahead == ')') ADVANCE(151);
-      if (lookahead == '*') ADVANCE(167);
-      if (lookahead == '+') ADVANCE(169);
-      if (lookahead == ',') ADVANCE(143);
-      if (lookahead == '-') ADVANCE(170);
-      if (lookahead == '.') ADVANCE(146);
-      if (lookahead == '/') ADVANCE(168);
-      if (lookahead == ':') ADVANCE(137);
-      if (lookahead == ';') ADVANCE(149);
-      if (lookahead == '<') ADVANCE(174);
-      if (lookahead == '=') ADVANCE(138);
-      if (lookahead == '>') ADVANCE(176);
-      if (lookahead == '?') ADVANCE(156);
-      if (lookahead == '@') ADVANCE(155);
-      if (lookahead == 'B') ADVANCE(102);
-      if (lookahead == 'D') ADVANCE(127);
-      if (lookahead == 'N') ADVANCE(123);
-      if (lookahead == 'S') ADVANCE(121);
-      if (lookahead == '[') ADVANCE(152);
-      if (lookahead == ']') ADVANCE(153);
-      if (lookahead == '_') ADVANCE(59);
-      if (lookahead == '`') ADVANCE(11);
-      if (lookahead == 'd') ADVANCE(81);
-      if (lookahead == 'e') ADVANCE(93);
-      if (lookahead == 'f') ADVANCE(72);
-      if (lookahead == 'i') ADVANCE(130);
-      if (lookahead == 'l') ADVANCE(83);
-      if (lookahead == 'm') ADVANCE(75);
-      if (lookahead == 'n') ADVANCE(124);
-      if (lookahead == 'o') ADVANCE(108);
-      if (lookahead == 'p') ADVANCE(109);
-      if (lookahead == 't') ADVANCE(89);
-      if (lookahead == '{') ADVANCE(142);
-      if (lookahead == '|') ADVANCE(135);
-      if (lookahead == '}') ADVANCE(144);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(63)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(68);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+      if (lookahead == 'u') ADVANCE(38);
       END_STATE();
     case 64:
-      if (eof) ADVANCE(65);
+      if (lookahead == 'u') ADVANCE(25);
+      END_STATE();
+    case 65:
+      if (lookahead == 'x') ADVANCE(49);
+      END_STATE();
+    case 66:
+      if (lookahead == 'y') ADVANCE(76);
+      END_STATE();
+    case 67:
+      if (lookahead == 'f' ||
+          lookahead == 'n') ADVANCE(76);
+      if (lookahead == 'm') ADVANCE(47);
+      END_STATE();
+    case 68:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(79);
+      END_STATE();
+    case 69:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(81);
+      END_STATE();
+    case 70:
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 71:
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      END_STATE();
+    case 72:
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(182);
+      END_STATE();
+    case 73:
+      if (eof) ADVANCE(75);
       if (lookahead == '!') ADVANCE(7);
-      if (lookahead == '%') ADVANCE(157);
-      if (lookahead == '&') ADVANCE(172);
-      if (lookahead == ')') ADVANCE(151);
-      if (lookahead == '*') ADVANCE(167);
-      if (lookahead == '+') ADVANCE(169);
-      if (lookahead == ',') ADVANCE(143);
-      if (lookahead == '-') ADVANCE(170);
-      if (lookahead == '.') ADVANCE(145);
-      if (lookahead == '/') ADVANCE(168);
-      if (lookahead == ':') ADVANCE(137);
-      if (lookahead == ';') ADVANCE(149);
-      if (lookahead == '<') ADVANCE(174);
-      if (lookahead == '=') ADVANCE(138);
-      if (lookahead == '>') ADVANCE(176);
-      if (lookahead == '?') ADVANCE(156);
-      if (lookahead == '@') ADVANCE(155);
-      if (lookahead == ']') ADVANCE(153);
-      if (lookahead == 'd') ADVANCE(20);
-      if (lookahead == 'e') ADVANCE(31);
-      if (lookahead == 'f') ADVANCE(13);
-      if (lookahead == 'i') ADVANCE(56);
-      if (lookahead == 'l') ADVANCE(23);
-      if (lookahead == 'm') ADVANCE(15);
-      if (lookahead == 'n') ADVANCE(52);
-      if (lookahead == 'o') ADVANCE(41);
-      if (lookahead == 'p') ADVANCE(43);
-      if (lookahead == 't') ADVANCE(27);
-      if (lookahead == '|') ADVANCE(135);
-      if (lookahead == '}') ADVANCE(144);
+      if (lookahead == '%') ADVANCE(175);
+      if (lookahead == '&') ADVANCE(190);
+      if (lookahead == '(') ADVANCE(168);
+      if (lookahead == ')') ADVANCE(169);
+      if (lookahead == '*') ADVANCE(185);
+      if (lookahead == '+') ADVANCE(187);
+      if (lookahead == ',') ADVANCE(161);
+      if (lookahead == '-') ADVANCE(188);
+      if (lookahead == '.') ADVANCE(164);
+      if (lookahead == '/') ADVANCE(186);
+      if (lookahead == ':') ADVANCE(155);
+      if (lookahead == ';') ADVANCE(167);
+      if (lookahead == '<') ADVANCE(192);
+      if (lookahead == '=') ADVANCE(156);
+      if (lookahead == '>') ADVANCE(194);
+      if (lookahead == '?') ADVANCE(174);
+      if (lookahead == '@') ADVANCE(173);
+      if (lookahead == 'B') ADVANCE(115);
+      if (lookahead == 'D') ADVANCE(146);
+      if (lookahead == 'N') ADVANCE(142);
+      if (lookahead == 'S') ADVANCE(139);
+      if (lookahead == '[') ADVANCE(170);
+      if (lookahead == ']') ADVANCE(171);
+      if (lookahead == '_') ADVANCE(70);
+      if (lookahead == '`') ADVANCE(11);
+      if (lookahead == 'd') ADVANCE(92);
+      if (lookahead == 'e') ADVANCE(106);
+      if (lookahead == 'f') ADVANCE(83);
+      if (lookahead == 'i') ADVANCE(149);
+      if (lookahead == 'l') ADVANCE(97);
+      if (lookahead == 'm') ADVANCE(87);
+      if (lookahead == 'n') ADVANCE(118);
+      if (lookahead == 'o') ADVANCE(123);
+      if (lookahead == 'p') ADVANCE(125);
+      if (lookahead == 'r') ADVANCE(93);
+      if (lookahead == 't') ADVANCE(102);
+      if (lookahead == '{') ADVANCE(160);
+      if (lookahead == '|') ADVANCE(154);
+      if (lookahead == '}') ADVANCE(162);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(64)
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(sym_keyword);
-      END_STATE();
-    case 67:
-      ACCEPT_TOKEN(sym_keyword);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 68:
-      ACCEPT_TOKEN(sym_num_literal);
-      if (lookahead == '.') ADVANCE(57);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(68);
-      END_STATE();
-    case 69:
-      ACCEPT_TOKEN(sym_num_literal);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(69);
-      END_STATE();
-    case 70:
-      ACCEPT_TOKEN(sym_signed_num_literal);
-      if (lookahead == '.') ADVANCE(58);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(70);
-      END_STATE();
-    case 71:
-      ACCEPT_TOKEN(sym_signed_num_literal);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(71);
-      END_STATE();
-    case 72:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(93);
-      if (lookahead == 'o') ADVANCE(112);
-      if (lookahead == 'u') ADVANCE(99);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 73:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(129);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          lookahead == ' ') SKIP(73)
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(78);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 74:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(97);
-      if (lookahead == 'c') ADVANCE(82);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+      if (eof) ADVANCE(75);
+      if (lookahead == '!') ADVANCE(7);
+      if (lookahead == '%') ADVANCE(175);
+      if (lookahead == '&') ADVANCE(190);
+      if (lookahead == ')') ADVANCE(169);
+      if (lookahead == '*') ADVANCE(185);
+      if (lookahead == '+') ADVANCE(187);
+      if (lookahead == ',') ADVANCE(161);
+      if (lookahead == '-') ADVANCE(188);
+      if (lookahead == '.') ADVANCE(163);
+      if (lookahead == '/') ADVANCE(186);
+      if (lookahead == ':') ADVANCE(155);
+      if (lookahead == ';') ADVANCE(167);
+      if (lookahead == '<') ADVANCE(192);
+      if (lookahead == '=') ADVANCE(156);
+      if (lookahead == '>') ADVANCE(194);
+      if (lookahead == '?') ADVANCE(174);
+      if (lookahead == '@') ADVANCE(173);
+      if (lookahead == ']') ADVANCE(171);
+      if (lookahead == 'd') ADVANCE(22);
+      if (lookahead == 'e') ADVANCE(36);
+      if (lookahead == 'f') ADVANCE(14);
+      if (lookahead == 'i') ADVANCE(67);
+      if (lookahead == 'l') ADVANCE(26);
+      if (lookahead == 'm') ADVANCE(16);
+      if (lookahead == 'n') ADVANCE(43);
+      if (lookahead == 'o') ADVANCE(48);
+      if (lookahead == 'p') ADVANCE(51);
+      if (lookahead == 'r') ADVANCE(23);
+      if (lookahead == 't') ADVANCE(32);
+      if (lookahead == '|') ADVANCE(154);
+      if (lookahead == '}') ADVANCE(162);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(74)
       END_STATE();
     case 75:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(120);
-      if (lookahead == 'e') ADVANCE(113);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 76:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(94);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+      ACCEPT_TOKEN(sym_keyword);
       END_STATE();
     case 77:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(126);
+      ACCEPT_TOKEN(sym_keyword);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 78:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'c') ADVANCE(67);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+      ACCEPT_TOKEN(sym_num_literal);
+      if (lookahead == '.') ADVANCE(68);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(78);
       END_STATE();
     case 79:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'c') ADVANCE(136);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+      ACCEPT_TOKEN(sym_num_literal);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(79);
       END_STATE();
     case 80:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'c') ADVANCE(88);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+      ACCEPT_TOKEN(sym_signed_num_literal);
+      if (lookahead == '.') ADVANCE(69);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(80);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(86);
-      if (lookahead == 'o') ADVANCE(78);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+      ACCEPT_TOKEN(sym_signed_num_literal);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(81);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(67);
+      if (lookahead == '_') ADVANCE(95);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(118);
+      if (lookahead == 'a') ADVANCE(106);
+      if (lookahead == 'o') ADVANCE(128);
+      if (lookahead == 'u') ADVANCE(112);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(99);
+      if (lookahead == 'a') ADVANCE(148);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(79);
+      if (lookahead == 'a') ADVANCE(110);
+      if (lookahead == 'c') ADVANCE(94);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'f') ADVANCE(77);
+      if (lookahead == 'a') ADVANCE(144);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'g') ADVANCE(82);
+      if (lookahead == 'a') ADVANCE(137);
+      if (lookahead == 'e') ADVANCE(129);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'h') ADVANCE(67);
+      if (lookahead == 'a') ADVANCE(107);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'h') ADVANCE(84);
-      if (lookahead == 'r') ADVANCE(125);
+      if (lookahead == 'c') ADVANCE(77);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 90:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'i') ADVANCE(104);
+      if (lookahead == 'c') ADVANCE(101);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 91:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'i') ADVANCE(119);
+      if (lookahead == 'd') ADVANCE(77);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'i') ADVANCE(106);
+      if (lookahead == 'e') ADVANCE(99);
+      if (lookahead == 'o') ADVANCE(89);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(117);
+      if (lookahead == 'e') ADVANCE(89);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(67);
+      if (lookahead == 'e') ADVANCE(77);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(184);
+      if (lookahead == 'e') ADVANCE(145);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(118);
+      if (lookahead == 'e') ADVANCE(91);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(94);
+      if (lookahead == 'e') ADVANCE(135);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'm') ADVANCE(183);
+      if (lookahead == 'e') ADVANCE(112);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'n') ADVANCE(67);
+      if (lookahead == 'f') ADVANCE(86);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'n') ADVANCE(148);
+      if (lookahead == 'g') ADVANCE(94);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'n') ADVANCE(76);
+      if (lookahead == 'h') ADVANCE(77);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'o') ADVANCE(103);
+      if (lookahead == 'h') ADVANCE(98);
+      if (lookahead == 'r') ADVANCE(143);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'o') ADVANCE(95);
+      if (lookahead == 'i') ADVANCE(117);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'o') ADVANCE(101);
+      if (lookahead == 'i') ADVANCE(138);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 105:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'i') ADVANCE(120);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 106:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'l') ADVANCE(134);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 107:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'l') ADVANCE(77);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 108:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'l') ADVANCE(202);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 109:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'l') ADVANCE(135);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 110:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'l') ADVANCE(107);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 111:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'm') ADVANCE(201);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 112:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'n') ADVANCE(77);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 113:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'n') ADVANCE(166);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 114:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'n') ADVANCE(88);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'o') ADVANCE(116);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 116:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'o') ADVANCE(108);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 117:
       ACCEPT_TOKEN(sym_ident);
       if (lookahead == 'o') ADVANCE(114);
       if (lookahead == '\'' ||
@@ -3269,169 +3291,200 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 106:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'o') ADVANCE(115);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 107:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'p') ADVANCE(105);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 108:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'p') ADVANCE(122);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 109:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(92);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 110:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(73);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(185);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 112:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(74);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 113:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(87);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 114:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(118);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 115:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(91);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 116:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(110);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 117:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 's') ADVANCE(82);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(67);
+      if (lookahead == 'o') ADVANCE(136);
+      if (lookahead == 'u') ADVANCE(110);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(128);
+      if (lookahead == 'o') ADVANCE(130);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(80);
+      if (lookahead == 'o') ADVANCE(131);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(111);
+      if (lookahead == 'o') ADVANCE(133);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 122:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'p') ADVANCE(119);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 123:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'p') ADVANCE(141);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 124:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'p') ADVANCE(121);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 125:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(105);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(84);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(203);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(85);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 129:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(100);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(135);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 131:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(104);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 132:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(126);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(140);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 134:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 's') ADVANCE(94);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 135:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 't') ADVANCE(77);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 136:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 't') ADVANCE(82);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 137:
       ACCEPT_TOKEN(sym_ident);
       if (lookahead == 't') ADVANCE(90);
       if (lookahead == '\'' ||
@@ -3439,353 +3492,384 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 123:
+    case 138:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'u') ADVANCE(98);
+      if (lookahead == 't') ADVANCE(147);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 124:
+    case 139:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'u') ADVANCE(97);
+      if (lookahead == 't') ADVANCE(127);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 125:
+    case 140:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'u') ADVANCE(82);
+      if (lookahead == 't') ADVANCE(96);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 126:
+    case 141:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'u') ADVANCE(96);
+      if (lookahead == 't') ADVANCE(103);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 127:
+    case 142:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'y') ADVANCE(100);
+      if (lookahead == 'u') ADVANCE(111);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 128:
+    case 143:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'y') ADVANCE(67);
+      if (lookahead == 'u') ADVANCE(94);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 129:
+    case 144:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'y') ADVANCE(147);
+      if (lookahead == 'u') ADVANCE(109);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 130:
+    case 145:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'x') ADVANCE(124);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 146:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'y') ADVANCE(113);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 147:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'y') ADVANCE(77);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 148:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'y') ADVANCE(165);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 149:
       ACCEPT_TOKEN(sym_ident);
       if (lookahead == 'f' ||
-          lookahead == 'n') ADVANCE(67);
-      if (lookahead == 'm') ADVANCE(107);
+          lookahead == 'n') ADVANCE(77);
+      if (lookahead == 'm') ADVANCE(122);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 131:
+    case 150:
       ACCEPT_TOKEN(sym_ident);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 132:
+    case 151:
       ACCEPT_TOKEN(sym_raw_enum_tag);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
       END_STATE();
-    case 133:
+    case 152:
       ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
-    case 134:
+    case 153:
       ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '>') ADVANCE(173);
-      if (lookahead == ']') ADVANCE(187);
-      if (lookahead == '|') ADVANCE(181);
+      if (lookahead == '>') ADVANCE(191);
+      if (lookahead == ']') ADVANCE(205);
+      if (lookahead == '|') ADVANCE(199);
       END_STATE();
-    case 135:
+    case 154:
       ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '>') ADVANCE(173);
-      if (lookahead == '|') ADVANCE(181);
+      if (lookahead == '>') ADVANCE(191);
+      if (lookahead == '|') ADVANCE(199);
       END_STATE();
-    case 136:
-      ACCEPT_TOKEN(anon_sym_rec);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 137:
+    case 155:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 138:
+    case 156:
       ACCEPT_TOKEN(anon_sym_EQ);
-      if (lookahead == '=') ADVANCE(178);
+      if (lookahead == '=') ADVANCE(196);
       END_STATE();
-    case 139:
+    case 157:
       ACCEPT_TOKEN(anon_sym_EQ);
-      if (lookahead == '=') ADVANCE(178);
-      if (lookahead == '>') ADVANCE(141);
+      if (lookahead == '=') ADVANCE(196);
+      if (lookahead == '>') ADVANCE(159);
       END_STATE();
-    case 140:
+    case 158:
       ACCEPT_TOKEN(anon_sym_EQ);
-      if (lookahead == '>') ADVANCE(141);
+      if (lookahead == '>') ADVANCE(159);
       END_STATE();
-    case 141:
+    case 159:
       ACCEPT_TOKEN(anon_sym_EQ_GT);
       END_STATE();
-    case 142:
+    case 160:
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
-    case 143:
+    case 161:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
-    case 144:
+    case 162:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 145:
+    case 163:
       ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
-    case 146:
+    case 164:
       ACCEPT_TOKEN(anon_sym_DOT);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(69);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(79);
       END_STATE();
-    case 147:
+    case 165:
       ACCEPT_TOKEN(anon_sym_Array);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 148:
+    case 166:
       ACCEPT_TOKEN(anon_sym_Dyn);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 149:
-      ACCEPT_TOKEN(anon_sym_SEMI);
-      END_STATE();
-    case 150:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      END_STATE();
-    case 151:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      END_STATE();
-    case 152:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      if (lookahead == '|') ADVANCE(186);
-      END_STATE();
-    case 153:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
-      END_STATE();
-    case 154:
-      ACCEPT_TOKEN(anon_sym_DOT_DOT);
-      END_STATE();
-    case 155:
-      ACCEPT_TOKEN(anon_sym_AT);
-      END_STATE();
-    case 156:
-      ACCEPT_TOKEN(anon_sym_QMARK);
-      END_STATE();
-    case 157:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
-      END_STATE();
-    case 158:
-      ACCEPT_TOKEN(sym_double_quote);
-      END_STATE();
-    case 159:
-      ACCEPT_TOKEN(sym_str_literal);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(159);
-      if (lookahead != 0 &&
-          lookahead != '"' &&
-          lookahead != '%' &&
-          lookahead != '\\') ADVANCE(160);
-      END_STATE();
-    case 160:
-      ACCEPT_TOKEN(sym_str_literal);
-      if (lookahead != 0 &&
-          lookahead != '"' &&
-          lookahead != '%' &&
-          lookahead != '\\') ADVANCE(160);
-      END_STATE();
-    case 161:
-      ACCEPT_TOKEN(sym_mult_str_literal);
-      if (lookahead == '\n') ADVANCE(163);
-      if (lookahead == '"' ||
-          lookahead == '%') ADVANCE(164);
-      if (lookahead != 0) ADVANCE(163);
-      END_STATE();
-    case 162:
-      ACCEPT_TOKEN(sym_mult_str_literal);
-      if (lookahead == '\\') ADVANCE(161);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(162);
-      if (lookahead != 0 &&
-          lookahead != '"' &&
-          lookahead != '%') ADVANCE(163);
-      END_STATE();
-    case 163:
-      ACCEPT_TOKEN(sym_mult_str_literal);
-      if (lookahead != 0 &&
-          lookahead != '"' &&
-          lookahead != '%') ADVANCE(163);
-      END_STATE();
-    case 164:
-      ACCEPT_TOKEN(sym_str_esc_char);
-      END_STATE();
-    case 165:
-      ACCEPT_TOKEN(anon_sym__);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
-      END_STATE();
-    case 166:
-      ACCEPT_TOKEN(anon_sym_PLUS_PLUS);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 167:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(anon_sym_SEMI);
       END_STATE();
     case 168:
-      ACCEPT_TOKEN(anon_sym_SLASH);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 169:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      if (lookahead == '+') ADVANCE(166);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 170:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '>') ADVANCE(182);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead == '|') ADVANCE(204);
       END_STATE();
     case 171:
-      ACCEPT_TOKEN(anon_sym_BANG);
-      if (lookahead == '=') ADVANCE(179);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 172:
-      ACCEPT_TOKEN(anon_sym_AMP);
-      if (lookahead == '&') ADVANCE(180);
+      ACCEPT_TOKEN(anon_sym_DOT_DOT);
       END_STATE();
     case 173:
-      ACCEPT_TOKEN(anon_sym_PIPE_GT);
+      ACCEPT_TOKEN(anon_sym_AT);
       END_STATE();
     case 174:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '=') ADVANCE(175);
+      ACCEPT_TOKEN(anon_sym_QMARK);
       END_STATE();
     case 175:
-      ACCEPT_TOKEN(anon_sym_LT_EQ);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
     case 176:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '=') ADVANCE(177);
+      ACCEPT_TOKEN(sym_double_quote);
       END_STATE();
     case 177:
-      ACCEPT_TOKEN(anon_sym_GT_EQ);
+      ACCEPT_TOKEN(sym_str_literal);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(177);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '%' &&
+          lookahead != '\\') ADVANCE(178);
       END_STATE();
     case 178:
-      ACCEPT_TOKEN(anon_sym_EQ_EQ);
+      ACCEPT_TOKEN(sym_str_literal);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '%' &&
+          lookahead != '\\') ADVANCE(178);
       END_STATE();
     case 179:
-      ACCEPT_TOKEN(anon_sym_BANG_EQ);
+      ACCEPT_TOKEN(sym_mult_str_literal);
+      if (lookahead == '\n') ADVANCE(181);
+      if (lookahead == '"' ||
+          lookahead == '%') ADVANCE(182);
+      if (lookahead != 0) ADVANCE(181);
       END_STATE();
     case 180:
-      ACCEPT_TOKEN(anon_sym_AMP_AMP);
+      ACCEPT_TOKEN(sym_mult_str_literal);
+      if (lookahead == '\\') ADVANCE(179);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(180);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '%') ADVANCE(181);
       END_STATE();
     case 181:
-      ACCEPT_TOKEN(anon_sym_PIPE_PIPE);
+      ACCEPT_TOKEN(sym_mult_str_literal);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '%') ADVANCE(181);
       END_STATE();
     case 182:
-      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      ACCEPT_TOKEN(sym_str_esc_char);
       END_STATE();
     case 183:
+      ACCEPT_TOKEN(anon_sym__);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 184:
+      ACCEPT_TOKEN(anon_sym_PLUS_PLUS);
+      END_STATE();
+    case 185:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      END_STATE();
+    case 186:
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      END_STATE();
+    case 187:
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      if (lookahead == '+') ADVANCE(184);
+      END_STATE();
+    case 188:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '>') ADVANCE(200);
+      END_STATE();
+    case 189:
+      ACCEPT_TOKEN(anon_sym_BANG);
+      if (lookahead == '=') ADVANCE(197);
+      END_STATE();
+    case 190:
+      ACCEPT_TOKEN(anon_sym_AMP);
+      if (lookahead == '&') ADVANCE(198);
+      END_STATE();
+    case 191:
+      ACCEPT_TOKEN(anon_sym_PIPE_GT);
+      END_STATE();
+    case 192:
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '=') ADVANCE(193);
+      END_STATE();
+    case 193:
+      ACCEPT_TOKEN(anon_sym_LT_EQ);
+      END_STATE();
+    case 194:
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '=') ADVANCE(195);
+      END_STATE();
+    case 195:
+      ACCEPT_TOKEN(anon_sym_GT_EQ);
+      END_STATE();
+    case 196:
+      ACCEPT_TOKEN(anon_sym_EQ_EQ);
+      END_STATE();
+    case 197:
+      ACCEPT_TOKEN(anon_sym_BANG_EQ);
+      END_STATE();
+    case 198:
+      ACCEPT_TOKEN(anon_sym_AMP_AMP);
+      END_STATE();
+    case 199:
+      ACCEPT_TOKEN(anon_sym_PIPE_PIPE);
+      END_STATE();
+    case 200:
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      END_STATE();
+    case 201:
       ACCEPT_TOKEN(anon_sym_Num);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 184:
+    case 202:
       ACCEPT_TOKEN(anon_sym_Bool);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 185:
+    case 203:
       ACCEPT_TOKEN(anon_sym_Str);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(131);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
-    case 186:
+    case 204:
       ACCEPT_TOKEN(anon_sym_LBRACK_PIPE);
       END_STATE();
-    case 187:
+    case 205:
       ACCEPT_TOKEN(anon_sym_PIPE_RBRACK);
       END_STATE();
     default:
@@ -3807,228 +3891,272 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'n') ADVANCE(7);
       if (lookahead == 'o') ADVANCE(8);
       if (lookahead == 'p') ADVANCE(9);
-      if (lookahead == 't') ADVANCE(10);
+      if (lookahead == 'r') ADVANCE(10);
+      if (lookahead == 't') ADVANCE(11);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
       END_STATE();
     case 1:
-      if (lookahead == 'e') ADVANCE(11);
-      if (lookahead == 'o') ADVANCE(12);
+      if (lookahead == 'e') ADVANCE(12);
+      if (lookahead == 'o') ADVANCE(13);
       END_STATE();
     case 2:
-      if (lookahead == 'l') ADVANCE(13);
+      if (lookahead == 'l') ADVANCE(14);
       END_STATE();
     case 3:
-      if (lookahead == 'a') ADVANCE(14);
-      if (lookahead == 'o') ADVANCE(15);
-      if (lookahead == 'u') ADVANCE(16);
+      if (lookahead == 'a') ADVANCE(15);
+      if (lookahead == 'o') ADVANCE(16);
+      if (lookahead == 'u') ADVANCE(17);
       END_STATE();
     case 4:
-      if (lookahead == 'f') ADVANCE(17);
-      if (lookahead == 'm') ADVANCE(18);
-      if (lookahead == 'n') ADVANCE(19);
+      if (lookahead == 'f') ADVANCE(18);
+      if (lookahead == 'm') ADVANCE(19);
+      if (lookahead == 'n') ADVANCE(20);
       END_STATE();
     case 5:
-      if (lookahead == 'e') ADVANCE(20);
+      if (lookahead == 'e') ADVANCE(21);
       END_STATE();
     case 6:
-      if (lookahead == 'a') ADVANCE(21);
+      if (lookahead == 'a') ADVANCE(22);
       END_STATE();
     case 7:
-      if (lookahead == 'u') ADVANCE(22);
+      if (lookahead == 'o') ADVANCE(23);
+      if (lookahead == 'u') ADVANCE(24);
       END_STATE();
     case 8:
-      if (lookahead == 'p') ADVANCE(23);
+      if (lookahead == 'p') ADVANCE(25);
       END_STATE();
     case 9:
-      if (lookahead == 'r') ADVANCE(24);
-      END_STATE();
-    case 10:
-      if (lookahead == 'h') ADVANCE(25);
       if (lookahead == 'r') ADVANCE(26);
       END_STATE();
+    case 10:
+      if (lookahead == 'e') ADVANCE(27);
+      END_STATE();
     case 11:
-      if (lookahead == 'f') ADVANCE(27);
+      if (lookahead == 'h') ADVANCE(28);
+      if (lookahead == 'r') ADVANCE(29);
       END_STATE();
     case 12:
-      if (lookahead == 'c') ADVANCE(28);
+      if (lookahead == 'f') ADVANCE(30);
       END_STATE();
     case 13:
-      if (lookahead == 's') ADVANCE(29);
+      if (lookahead == 'c') ADVANCE(31);
       END_STATE();
     case 14:
-      if (lookahead == 'l') ADVANCE(30);
+      if (lookahead == 's') ADVANCE(32);
       END_STATE();
     case 15:
-      if (lookahead == 'r') ADVANCE(31);
+      if (lookahead == 'l') ADVANCE(33);
       END_STATE();
     case 16:
-      if (lookahead == 'n') ADVANCE(32);
+      if (lookahead == 'r') ADVANCE(34);
       END_STATE();
     case 17:
-      ACCEPT_TOKEN(anon_sym_if);
+      if (lookahead == 'n') ADVANCE(35);
       END_STATE();
     case 18:
-      if (lookahead == 'p') ADVANCE(33);
+      ACCEPT_TOKEN(anon_sym_if);
       END_STATE();
     case 19:
-      ACCEPT_TOKEN(anon_sym_in);
+      if (lookahead == 'p') ADVANCE(36);
       END_STATE();
     case 20:
-      if (lookahead == 't') ADVANCE(34);
+      ACCEPT_TOKEN(anon_sym_in);
       END_STATE();
     case 21:
-      if (lookahead == 't') ADVANCE(35);
-      END_STATE();
-    case 22:
-      if (lookahead == 'l') ADVANCE(36);
-      END_STATE();
-    case 23:
       if (lookahead == 't') ADVANCE(37);
       END_STATE();
+    case 22:
+      if (lookahead == 't') ADVANCE(38);
+      END_STATE();
+    case 23:
+      if (lookahead == 't') ADVANCE(39);
+      END_STATE();
     case 24:
-      if (lookahead == 'i') ADVANCE(38);
+      if (lookahead == 'l') ADVANCE(40);
       END_STATE();
     case 25:
-      if (lookahead == 'e') ADVANCE(39);
+      if (lookahead == 't') ADVANCE(41);
       END_STATE();
     case 26:
-      if (lookahead == 'u') ADVANCE(40);
+      if (lookahead == 'i') ADVANCE(42);
       END_STATE();
     case 27:
-      if (lookahead == 'a') ADVANCE(41);
+      if (lookahead == 'c') ADVANCE(43);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(anon_sym_doc);
+      if (lookahead == 'e') ADVANCE(44);
       END_STATE();
     case 29:
-      if (lookahead == 'e') ADVANCE(42);
+      if (lookahead == 'u') ADVANCE(45);
       END_STATE();
     case 30:
-      if (lookahead == 's') ADVANCE(43);
+      if (lookahead == 'a') ADVANCE(46);
       END_STATE();
     case 31:
-      if (lookahead == 'a') ADVANCE(44);
-      if (lookahead == 'c') ADVANCE(45);
+      ACCEPT_TOKEN(anon_sym_doc);
       END_STATE();
     case 32:
-      ACCEPT_TOKEN(anon_sym_fun);
+      if (lookahead == 'e') ADVANCE(47);
       END_STATE();
     case 33:
-      if (lookahead == 'o') ADVANCE(46);
+      if (lookahead == 's') ADVANCE(48);
       END_STATE();
     case 34:
-      ACCEPT_TOKEN(anon_sym_let);
+      if (lookahead == 'a') ADVANCE(49);
+      if (lookahead == 'c') ADVANCE(50);
       END_STATE();
     case 35:
-      if (lookahead == 'c') ADVANCE(47);
+      ACCEPT_TOKEN(anon_sym_fun);
       END_STATE();
     case 36:
-      if (lookahead == 'l') ADVANCE(48);
+      if (lookahead == 'o') ADVANCE(51);
       END_STATE();
     case 37:
-      if (lookahead == 'i') ADVANCE(49);
+      ACCEPT_TOKEN(anon_sym_let);
       END_STATE();
     case 38:
-      if (lookahead == 'o') ADVANCE(50);
+      if (lookahead == 'c') ADVANCE(52);
       END_STATE();
     case 39:
-      if (lookahead == 'n') ADVANCE(51);
+      if (lookahead == '_') ADVANCE(53);
       END_STATE();
     case 40:
-      if (lookahead == 'e') ADVANCE(52);
+      if (lookahead == 'l') ADVANCE(54);
       END_STATE();
     case 41:
-      if (lookahead == 'u') ADVANCE(53);
+      if (lookahead == 'i') ADVANCE(55);
       END_STATE();
     case 42:
-      ACCEPT_TOKEN(anon_sym_else);
+      if (lookahead == 'o') ADVANCE(56);
       END_STATE();
     case 43:
-      if (lookahead == 'e') ADVANCE(54);
+      ACCEPT_TOKEN(anon_sym_rec);
       END_STATE();
     case 44:
-      if (lookahead == 'l') ADVANCE(55);
+      if (lookahead == 'n') ADVANCE(57);
       END_STATE();
     case 45:
-      if (lookahead == 'e') ADVANCE(56);
+      if (lookahead == 'e') ADVANCE(58);
       END_STATE();
     case 46:
-      if (lookahead == 'r') ADVANCE(57);
+      if (lookahead == 'u') ADVANCE(59);
       END_STATE();
     case 47:
-      if (lookahead == 'h') ADVANCE(58);
+      ACCEPT_TOKEN(anon_sym_else);
       END_STATE();
     case 48:
-      ACCEPT_TOKEN(anon_sym_null);
+      if (lookahead == 'e') ADVANCE(60);
       END_STATE();
     case 49:
-      if (lookahead == 'o') ADVANCE(59);
-      END_STATE();
-    case 50:
-      if (lookahead == 'r') ADVANCE(60);
-      END_STATE();
-    case 51:
-      ACCEPT_TOKEN(anon_sym_then);
-      END_STATE();
-    case 52:
-      ACCEPT_TOKEN(anon_sym_true);
-      END_STATE();
-    case 53:
       if (lookahead == 'l') ADVANCE(61);
       END_STATE();
+    case 50:
+      if (lookahead == 'e') ADVANCE(62);
+      END_STATE();
+    case 51:
+      if (lookahead == 'r') ADVANCE(63);
+      END_STATE();
+    case 52:
+      if (lookahead == 'h') ADVANCE(64);
+      END_STATE();
+    case 53:
+      if (lookahead == 'e') ADVANCE(65);
+      END_STATE();
     case 54:
-      ACCEPT_TOKEN(anon_sym_false);
+      ACCEPT_TOKEN(anon_sym_null);
       END_STATE();
     case 55:
-      if (lookahead == 'l') ADVANCE(62);
+      if (lookahead == 'o') ADVANCE(66);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(anon_sym_force);
+      if (lookahead == 'r') ADVANCE(67);
       END_STATE();
     case 57:
-      if (lookahead == 't') ADVANCE(63);
+      ACCEPT_TOKEN(anon_sym_then);
       END_STATE();
     case 58:
-      ACCEPT_TOKEN(anon_sym_match);
+      ACCEPT_TOKEN(anon_sym_true);
       END_STATE();
     case 59:
-      if (lookahead == 'n') ADVANCE(64);
+      if (lookahead == 'l') ADVANCE(68);
       END_STATE();
     case 60:
-      if (lookahead == 'i') ADVANCE(65);
+      ACCEPT_TOKEN(anon_sym_false);
       END_STATE();
     case 61:
-      if (lookahead == 't') ADVANCE(66);
-      END_STATE();
-    case 62:
-      ACCEPT_TOKEN(anon_sym_forall);
-      END_STATE();
-    case 63:
-      ACCEPT_TOKEN(anon_sym_import);
-      END_STATE();
-    case 64:
-      if (lookahead == 'a') ADVANCE(67);
-      END_STATE();
-    case 65:
-      if (lookahead == 't') ADVANCE(68);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(anon_sym_default);
-      END_STATE();
-    case 67:
       if (lookahead == 'l') ADVANCE(69);
       END_STATE();
+    case 62:
+      ACCEPT_TOKEN(anon_sym_force);
+      END_STATE();
+    case 63:
+      if (lookahead == 't') ADVANCE(70);
+      END_STATE();
+    case 64:
+      ACCEPT_TOKEN(anon_sym_match);
+      END_STATE();
+    case 65:
+      if (lookahead == 'x') ADVANCE(71);
+      END_STATE();
+    case 66:
+      if (lookahead == 'n') ADVANCE(72);
+      END_STATE();
+    case 67:
+      if (lookahead == 'i') ADVANCE(73);
+      END_STATE();
     case 68:
-      if (lookahead == 'y') ADVANCE(70);
+      if (lookahead == 't') ADVANCE(74);
       END_STATE();
     case 69:
-      ACCEPT_TOKEN(anon_sym_optional);
+      ACCEPT_TOKEN(anon_sym_forall);
       END_STATE();
     case 70:
+      ACCEPT_TOKEN(anon_sym_import);
+      END_STATE();
+    case 71:
+      if (lookahead == 'p') ADVANCE(75);
+      END_STATE();
+    case 72:
+      if (lookahead == 'a') ADVANCE(76);
+      END_STATE();
+    case 73:
+      if (lookahead == 't') ADVANCE(77);
+      END_STATE();
+    case 74:
+      ACCEPT_TOKEN(anon_sym_default);
+      END_STATE();
+    case 75:
+      if (lookahead == 'o') ADVANCE(78);
+      END_STATE();
+    case 76:
+      if (lookahead == 'l') ADVANCE(79);
+      END_STATE();
+    case 77:
+      if (lookahead == 'y') ADVANCE(80);
+      END_STATE();
+    case 78:
+      if (lookahead == 'r') ADVANCE(81);
+      END_STATE();
+    case 79:
+      ACCEPT_TOKEN(anon_sym_optional);
+      END_STATE();
+    case 80:
       ACCEPT_TOKEN(anon_sym_priority);
+      END_STATE();
+    case 81:
+      if (lookahead == 't') ADVANCE(82);
+      END_STATE();
+    case 82:
+      if (lookahead == 'e') ADVANCE(83);
+      END_STATE();
+    case 83:
+      if (lookahead == 'd') ADVANCE(84);
+      END_STATE();
+    case 84:
+      ACCEPT_TOKEN(anon_sym_not_exported);
       END_STATE();
     default:
       return false;
@@ -4037,550 +4165,550 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0, .external_lex_state = 1},
-  [1] = {.lex_state = 62, .external_lex_state = 2},
-  [2] = {.lex_state = 62, .external_lex_state = 2},
-  [3] = {.lex_state = 62, .external_lex_state = 2},
-  [4] = {.lex_state = 62, .external_lex_state = 2},
-  [5] = {.lex_state = 62, .external_lex_state = 2},
-  [6] = {.lex_state = 62, .external_lex_state = 2},
-  [7] = {.lex_state = 62, .external_lex_state = 2},
-  [8] = {.lex_state = 63, .external_lex_state = 2},
-  [9] = {.lex_state = 62, .external_lex_state = 2},
-  [10] = {.lex_state = 62, .external_lex_state = 2},
-  [11] = {.lex_state = 62, .external_lex_state = 2},
-  [12] = {.lex_state = 62, .external_lex_state = 2},
-  [13] = {.lex_state = 62, .external_lex_state = 2},
-  [14] = {.lex_state = 62, .external_lex_state = 2},
-  [15] = {.lex_state = 62, .external_lex_state = 2},
-  [16] = {.lex_state = 62, .external_lex_state = 2},
-  [17] = {.lex_state = 62, .external_lex_state = 2},
-  [18] = {.lex_state = 62, .external_lex_state = 2},
-  [19] = {.lex_state = 62, .external_lex_state = 2},
-  [20] = {.lex_state = 62, .external_lex_state = 2},
-  [21] = {.lex_state = 62, .external_lex_state = 2},
-  [22] = {.lex_state = 62, .external_lex_state = 2},
-  [23] = {.lex_state = 62, .external_lex_state = 2},
-  [24] = {.lex_state = 62, .external_lex_state = 2},
-  [25] = {.lex_state = 62, .external_lex_state = 2},
-  [26] = {.lex_state = 62, .external_lex_state = 2},
-  [27] = {.lex_state = 62, .external_lex_state = 2},
-  [28] = {.lex_state = 62, .external_lex_state = 2},
-  [29] = {.lex_state = 62, .external_lex_state = 2},
-  [30] = {.lex_state = 62, .external_lex_state = 2},
-  [31] = {.lex_state = 62, .external_lex_state = 2},
-  [32] = {.lex_state = 62, .external_lex_state = 2},
-  [33] = {.lex_state = 62, .external_lex_state = 2},
-  [34] = {.lex_state = 62, .external_lex_state = 2},
-  [35] = {.lex_state = 62, .external_lex_state = 2},
-  [36] = {.lex_state = 62, .external_lex_state = 2},
-  [37] = {.lex_state = 62, .external_lex_state = 2},
-  [38] = {.lex_state = 62, .external_lex_state = 2},
-  [39] = {.lex_state = 62, .external_lex_state = 2},
-  [40] = {.lex_state = 62, .external_lex_state = 2},
-  [41] = {.lex_state = 62, .external_lex_state = 2},
-  [42] = {.lex_state = 62, .external_lex_state = 2},
-  [43] = {.lex_state = 62, .external_lex_state = 2},
-  [44] = {.lex_state = 62, .external_lex_state = 2},
-  [45] = {.lex_state = 62, .external_lex_state = 2},
-  [46] = {.lex_state = 62, .external_lex_state = 2},
-  [47] = {.lex_state = 62, .external_lex_state = 2},
-  [48] = {.lex_state = 62, .external_lex_state = 2},
-  [49] = {.lex_state = 62, .external_lex_state = 2},
-  [50] = {.lex_state = 62, .external_lex_state = 2},
-  [51] = {.lex_state = 62, .external_lex_state = 2},
-  [52] = {.lex_state = 62, .external_lex_state = 2},
-  [53] = {.lex_state = 62, .external_lex_state = 2},
-  [54] = {.lex_state = 62, .external_lex_state = 2},
-  [55] = {.lex_state = 62, .external_lex_state = 2},
-  [56] = {.lex_state = 62, .external_lex_state = 2},
-  [57] = {.lex_state = 62, .external_lex_state = 2},
-  [58] = {.lex_state = 62, .external_lex_state = 2},
-  [59] = {.lex_state = 62, .external_lex_state = 2},
-  [60] = {.lex_state = 62, .external_lex_state = 2},
-  [61] = {.lex_state = 62, .external_lex_state = 2},
-  [62] = {.lex_state = 62, .external_lex_state = 2},
-  [63] = {.lex_state = 62, .external_lex_state = 2},
-  [64] = {.lex_state = 62, .external_lex_state = 2},
-  [65] = {.lex_state = 62, .external_lex_state = 2},
-  [66] = {.lex_state = 62, .external_lex_state = 2},
-  [67] = {.lex_state = 62, .external_lex_state = 2},
-  [68] = {.lex_state = 62, .external_lex_state = 2},
-  [69] = {.lex_state = 63, .external_lex_state = 2},
-  [70] = {.lex_state = 63, .external_lex_state = 2},
-  [71] = {.lex_state = 63, .external_lex_state = 3},
-  [72] = {.lex_state = 63, .external_lex_state = 2},
-  [73] = {.lex_state = 63, .external_lex_state = 2},
+  [1] = {.lex_state = 0, .external_lex_state = 2},
+  [2] = {.lex_state = 0, .external_lex_state = 2},
+  [3] = {.lex_state = 0, .external_lex_state = 2},
+  [4] = {.lex_state = 0, .external_lex_state = 2},
+  [5] = {.lex_state = 0, .external_lex_state = 2},
+  [6] = {.lex_state = 0, .external_lex_state = 2},
+  [7] = {.lex_state = 0, .external_lex_state = 2},
+  [8] = {.lex_state = 73, .external_lex_state = 2},
+  [9] = {.lex_state = 0, .external_lex_state = 2},
+  [10] = {.lex_state = 0, .external_lex_state = 2},
+  [11] = {.lex_state = 0, .external_lex_state = 2},
+  [12] = {.lex_state = 0, .external_lex_state = 2},
+  [13] = {.lex_state = 0, .external_lex_state = 2},
+  [14] = {.lex_state = 0, .external_lex_state = 2},
+  [15] = {.lex_state = 0, .external_lex_state = 2},
+  [16] = {.lex_state = 0, .external_lex_state = 2},
+  [17] = {.lex_state = 0, .external_lex_state = 2},
+  [18] = {.lex_state = 0, .external_lex_state = 2},
+  [19] = {.lex_state = 0, .external_lex_state = 2},
+  [20] = {.lex_state = 0, .external_lex_state = 2},
+  [21] = {.lex_state = 0, .external_lex_state = 2},
+  [22] = {.lex_state = 0, .external_lex_state = 2},
+  [23] = {.lex_state = 0, .external_lex_state = 2},
+  [24] = {.lex_state = 0, .external_lex_state = 2},
+  [25] = {.lex_state = 0, .external_lex_state = 2},
+  [26] = {.lex_state = 0, .external_lex_state = 2},
+  [27] = {.lex_state = 0, .external_lex_state = 2},
+  [28] = {.lex_state = 0, .external_lex_state = 2},
+  [29] = {.lex_state = 0, .external_lex_state = 2},
+  [30] = {.lex_state = 0, .external_lex_state = 2},
+  [31] = {.lex_state = 0, .external_lex_state = 2},
+  [32] = {.lex_state = 0, .external_lex_state = 2},
+  [33] = {.lex_state = 0, .external_lex_state = 2},
+  [34] = {.lex_state = 0, .external_lex_state = 2},
+  [35] = {.lex_state = 0, .external_lex_state = 2},
+  [36] = {.lex_state = 0, .external_lex_state = 2},
+  [37] = {.lex_state = 0, .external_lex_state = 2},
+  [38] = {.lex_state = 0, .external_lex_state = 2},
+  [39] = {.lex_state = 0, .external_lex_state = 2},
+  [40] = {.lex_state = 0, .external_lex_state = 2},
+  [41] = {.lex_state = 0, .external_lex_state = 2},
+  [42] = {.lex_state = 0, .external_lex_state = 2},
+  [43] = {.lex_state = 0, .external_lex_state = 2},
+  [44] = {.lex_state = 0, .external_lex_state = 2},
+  [45] = {.lex_state = 0, .external_lex_state = 2},
+  [46] = {.lex_state = 0, .external_lex_state = 2},
+  [47] = {.lex_state = 0, .external_lex_state = 2},
+  [48] = {.lex_state = 0, .external_lex_state = 2},
+  [49] = {.lex_state = 0, .external_lex_state = 2},
+  [50] = {.lex_state = 0, .external_lex_state = 2},
+  [51] = {.lex_state = 0, .external_lex_state = 2},
+  [52] = {.lex_state = 0, .external_lex_state = 2},
+  [53] = {.lex_state = 0, .external_lex_state = 2},
+  [54] = {.lex_state = 0, .external_lex_state = 2},
+  [55] = {.lex_state = 0, .external_lex_state = 2},
+  [56] = {.lex_state = 0, .external_lex_state = 2},
+  [57] = {.lex_state = 0, .external_lex_state = 2},
+  [58] = {.lex_state = 0, .external_lex_state = 2},
+  [59] = {.lex_state = 0, .external_lex_state = 2},
+  [60] = {.lex_state = 0, .external_lex_state = 2},
+  [61] = {.lex_state = 0, .external_lex_state = 2},
+  [62] = {.lex_state = 0, .external_lex_state = 2},
+  [63] = {.lex_state = 0, .external_lex_state = 2},
+  [64] = {.lex_state = 0, .external_lex_state = 2},
+  [65] = {.lex_state = 0, .external_lex_state = 2},
+  [66] = {.lex_state = 0, .external_lex_state = 2},
+  [67] = {.lex_state = 0, .external_lex_state = 2},
+  [68] = {.lex_state = 0, .external_lex_state = 2},
+  [69] = {.lex_state = 0, .external_lex_state = 2},
+  [70] = {.lex_state = 73, .external_lex_state = 2},
+  [71] = {.lex_state = 0, .external_lex_state = 2},
+  [72] = {.lex_state = 0, .external_lex_state = 2},
+  [73] = {.lex_state = 73, .external_lex_state = 2},
   [74] = {.lex_state = 0, .external_lex_state = 2},
   [75] = {.lex_state = 0, .external_lex_state = 2},
   [76] = {.lex_state = 0, .external_lex_state = 2},
-  [77] = {.lex_state = 0, .external_lex_state = 2},
-  [78] = {.lex_state = 0, .external_lex_state = 2},
-  [79] = {.lex_state = 0, .external_lex_state = 2},
-  [80] = {.lex_state = 63, .external_lex_state = 2},
-  [81] = {.lex_state = 63, .external_lex_state = 2},
-  [82] = {.lex_state = 63, .external_lex_state = 2},
-  [83] = {.lex_state = 63, .external_lex_state = 2},
-  [84] = {.lex_state = 63, .external_lex_state = 2},
-  [85] = {.lex_state = 63, .external_lex_state = 2},
-  [86] = {.lex_state = 63, .external_lex_state = 2},
-  [87] = {.lex_state = 63, .external_lex_state = 2},
-  [88] = {.lex_state = 63, .external_lex_state = 2},
-  [89] = {.lex_state = 63, .external_lex_state = 2},
-  [90] = {.lex_state = 63, .external_lex_state = 2},
-  [91] = {.lex_state = 63, .external_lex_state = 2},
-  [92] = {.lex_state = 63, .external_lex_state = 2},
-  [93] = {.lex_state = 63, .external_lex_state = 2},
-  [94] = {.lex_state = 63, .external_lex_state = 2},
-  [95] = {.lex_state = 63, .external_lex_state = 2},
-  [96] = {.lex_state = 63, .external_lex_state = 2},
-  [97] = {.lex_state = 63, .external_lex_state = 2},
-  [98] = {.lex_state = 63, .external_lex_state = 2},
-  [99] = {.lex_state = 63, .external_lex_state = 2},
-  [100] = {.lex_state = 63, .external_lex_state = 2},
-  [101] = {.lex_state = 63, .external_lex_state = 2},
-  [102] = {.lex_state = 63, .external_lex_state = 2},
-  [103] = {.lex_state = 63, .external_lex_state = 2},
-  [104] = {.lex_state = 63, .external_lex_state = 2},
-  [105] = {.lex_state = 63, .external_lex_state = 2},
-  [106] = {.lex_state = 63, .external_lex_state = 2},
-  [107] = {.lex_state = 63, .external_lex_state = 2},
-  [108] = {.lex_state = 63, .external_lex_state = 2},
-  [109] = {.lex_state = 63, .external_lex_state = 2},
-  [110] = {.lex_state = 63, .external_lex_state = 2},
-  [111] = {.lex_state = 63, .external_lex_state = 2},
-  [112] = {.lex_state = 63, .external_lex_state = 2},
-  [113] = {.lex_state = 63, .external_lex_state = 2},
-  [114] = {.lex_state = 63, .external_lex_state = 2},
-  [115] = {.lex_state = 63, .external_lex_state = 2},
-  [116] = {.lex_state = 63, .external_lex_state = 2},
-  [117] = {.lex_state = 63, .external_lex_state = 2},
-  [118] = {.lex_state = 63, .external_lex_state = 2},
-  [119] = {.lex_state = 63, .external_lex_state = 2},
-  [120] = {.lex_state = 63, .external_lex_state = 2},
-  [121] = {.lex_state = 62, .external_lex_state = 2},
-  [122] = {.lex_state = 62, .external_lex_state = 2},
-  [123] = {.lex_state = 62, .external_lex_state = 2},
-  [124] = {.lex_state = 62, .external_lex_state = 2},
-  [125] = {.lex_state = 62, .external_lex_state = 2},
-  [126] = {.lex_state = 62, .external_lex_state = 2},
-  [127] = {.lex_state = 63, .external_lex_state = 2},
-  [128] = {.lex_state = 62, .external_lex_state = 2},
-  [129] = {.lex_state = 62, .external_lex_state = 2},
-  [130] = {.lex_state = 62, .external_lex_state = 2},
-  [131] = {.lex_state = 63, .external_lex_state = 2},
-  [132] = {.lex_state = 62, .external_lex_state = 2},
-  [133] = {.lex_state = 63, .external_lex_state = 2},
-  [134] = {.lex_state = 62, .external_lex_state = 2},
-  [135] = {.lex_state = 62, .external_lex_state = 2},
-  [136] = {.lex_state = 62, .external_lex_state = 2},
-  [137] = {.lex_state = 63, .external_lex_state = 2},
-  [138] = {.lex_state = 62, .external_lex_state = 2},
-  [139] = {.lex_state = 62, .external_lex_state = 2},
-  [140] = {.lex_state = 63, .external_lex_state = 2},
-  [141] = {.lex_state = 62, .external_lex_state = 2},
-  [142] = {.lex_state = 62, .external_lex_state = 2},
-  [143] = {.lex_state = 63, .external_lex_state = 2},
-  [144] = {.lex_state = 62, .external_lex_state = 2},
-  [145] = {.lex_state = 62, .external_lex_state = 2},
-  [146] = {.lex_state = 62, .external_lex_state = 2},
-  [147] = {.lex_state = 62, .external_lex_state = 2},
-  [148] = {.lex_state = 62, .external_lex_state = 2},
-  [149] = {.lex_state = 62, .external_lex_state = 2},
-  [150] = {.lex_state = 62, .external_lex_state = 2},
-  [151] = {.lex_state = 62, .external_lex_state = 2},
-  [152] = {.lex_state = 62, .external_lex_state = 2},
-  [153] = {.lex_state = 62, .external_lex_state = 2},
-  [154] = {.lex_state = 62, .external_lex_state = 2},
-  [155] = {.lex_state = 62, .external_lex_state = 2},
-  [156] = {.lex_state = 62, .external_lex_state = 2},
-  [157] = {.lex_state = 62, .external_lex_state = 2},
-  [158] = {.lex_state = 62, .external_lex_state = 2},
-  [159] = {.lex_state = 62, .external_lex_state = 2},
-  [160] = {.lex_state = 62, .external_lex_state = 2},
-  [161] = {.lex_state = 62, .external_lex_state = 2},
-  [162] = {.lex_state = 62, .external_lex_state = 2},
-  [163] = {.lex_state = 62, .external_lex_state = 2},
-  [164] = {.lex_state = 62, .external_lex_state = 2},
-  [165] = {.lex_state = 62, .external_lex_state = 2},
-  [166] = {.lex_state = 62, .external_lex_state = 2},
-  [167] = {.lex_state = 62, .external_lex_state = 2},
-  [168] = {.lex_state = 62, .external_lex_state = 2},
-  [169] = {.lex_state = 62, .external_lex_state = 2},
-  [170] = {.lex_state = 62, .external_lex_state = 2},
-  [171] = {.lex_state = 62, .external_lex_state = 2},
-  [172] = {.lex_state = 62, .external_lex_state = 2},
-  [173] = {.lex_state = 62, .external_lex_state = 2},
-  [174] = {.lex_state = 62, .external_lex_state = 2},
-  [175] = {.lex_state = 62, .external_lex_state = 2},
-  [176] = {.lex_state = 62, .external_lex_state = 2},
-  [177] = {.lex_state = 62, .external_lex_state = 2},
-  [178] = {.lex_state = 62, .external_lex_state = 2},
-  [179] = {.lex_state = 62, .external_lex_state = 2},
-  [180] = {.lex_state = 62, .external_lex_state = 2},
-  [181] = {.lex_state = 62, .external_lex_state = 2},
-  [182] = {.lex_state = 62, .external_lex_state = 2},
-  [183] = {.lex_state = 62, .external_lex_state = 2},
-  [184] = {.lex_state = 62, .external_lex_state = 2},
-  [185] = {.lex_state = 62, .external_lex_state = 2},
-  [186] = {.lex_state = 62, .external_lex_state = 2},
-  [187] = {.lex_state = 62, .external_lex_state = 2},
-  [188] = {.lex_state = 62, .external_lex_state = 2},
-  [189] = {.lex_state = 62, .external_lex_state = 2},
-  [190] = {.lex_state = 62, .external_lex_state = 2},
-  [191] = {.lex_state = 62, .external_lex_state = 2},
-  [192] = {.lex_state = 62, .external_lex_state = 2},
-  [193] = {.lex_state = 62, .external_lex_state = 2},
-  [194] = {.lex_state = 62, .external_lex_state = 2},
-  [195] = {.lex_state = 62, .external_lex_state = 2},
-  [196] = {.lex_state = 62, .external_lex_state = 2},
-  [197] = {.lex_state = 62, .external_lex_state = 2},
-  [198] = {.lex_state = 62, .external_lex_state = 2},
-  [199] = {.lex_state = 62, .external_lex_state = 2},
-  [200] = {.lex_state = 62, .external_lex_state = 2},
-  [201] = {.lex_state = 62, .external_lex_state = 2},
-  [202] = {.lex_state = 62, .external_lex_state = 2},
-  [203] = {.lex_state = 62, .external_lex_state = 2},
-  [204] = {.lex_state = 62, .external_lex_state = 2},
-  [205] = {.lex_state = 62, .external_lex_state = 2},
-  [206] = {.lex_state = 62, .external_lex_state = 2},
-  [207] = {.lex_state = 62, .external_lex_state = 2},
-  [208] = {.lex_state = 62, .external_lex_state = 2},
-  [209] = {.lex_state = 62, .external_lex_state = 2},
-  [210] = {.lex_state = 62, .external_lex_state = 2},
-  [211] = {.lex_state = 62, .external_lex_state = 2},
-  [212] = {.lex_state = 62, .external_lex_state = 2},
-  [213] = {.lex_state = 63, .external_lex_state = 3},
-  [214] = {.lex_state = 63, .external_lex_state = 3},
-  [215] = {.lex_state = 63, .external_lex_state = 2},
-  [216] = {.lex_state = 63, .external_lex_state = 2},
-  [217] = {.lex_state = 63, .external_lex_state = 2},
-  [218] = {.lex_state = 63, .external_lex_state = 2},
-  [219] = {.lex_state = 63, .external_lex_state = 2},
-  [220] = {.lex_state = 63, .external_lex_state = 2},
-  [221] = {.lex_state = 63, .external_lex_state = 3},
-  [222] = {.lex_state = 63, .external_lex_state = 3},
-  [223] = {.lex_state = 63, .external_lex_state = 2},
-  [224] = {.lex_state = 63, .external_lex_state = 2},
-  [225] = {.lex_state = 63, .external_lex_state = 2},
-  [226] = {.lex_state = 63, .external_lex_state = 2},
-  [227] = {.lex_state = 63, .external_lex_state = 2},
-  [228] = {.lex_state = 63, .external_lex_state = 2},
-  [229] = {.lex_state = 63, .external_lex_state = 2},
-  [230] = {.lex_state = 63, .external_lex_state = 2},
-  [231] = {.lex_state = 63, .external_lex_state = 3},
-  [232] = {.lex_state = 63, .external_lex_state = 3},
-  [233] = {.lex_state = 63, .external_lex_state = 2},
-  [234] = {.lex_state = 63, .external_lex_state = 2},
-  [235] = {.lex_state = 63, .external_lex_state = 2},
-  [236] = {.lex_state = 63, .external_lex_state = 2},
-  [237] = {.lex_state = 63, .external_lex_state = 2},
-  [238] = {.lex_state = 63, .external_lex_state = 2},
-  [239] = {.lex_state = 63, .external_lex_state = 2},
-  [240] = {.lex_state = 63, .external_lex_state = 2},
-  [241] = {.lex_state = 63, .external_lex_state = 2},
-  [242] = {.lex_state = 63, .external_lex_state = 2},
-  [243] = {.lex_state = 63, .external_lex_state = 2},
-  [244] = {.lex_state = 63, .external_lex_state = 2},
-  [245] = {.lex_state = 63, .external_lex_state = 2},
-  [246] = {.lex_state = 63, .external_lex_state = 2},
-  [247] = {.lex_state = 63, .external_lex_state = 2},
-  [248] = {.lex_state = 63, .external_lex_state = 3},
-  [249] = {.lex_state = 63, .external_lex_state = 2},
-  [250] = {.lex_state = 63, .external_lex_state = 2},
-  [251] = {.lex_state = 63, .external_lex_state = 2},
-  [252] = {.lex_state = 63, .external_lex_state = 2},
-  [253] = {.lex_state = 63, .external_lex_state = 2},
-  [254] = {.lex_state = 63, .external_lex_state = 2},
-  [255] = {.lex_state = 63, .external_lex_state = 2},
-  [256] = {.lex_state = 63, .external_lex_state = 2},
-  [257] = {.lex_state = 63, .external_lex_state = 2},
-  [258] = {.lex_state = 63, .external_lex_state = 2},
-  [259] = {.lex_state = 63, .external_lex_state = 2},
-  [260] = {.lex_state = 63, .external_lex_state = 2},
-  [261] = {.lex_state = 63, .external_lex_state = 2},
-  [262] = {.lex_state = 63, .external_lex_state = 2},
-  [263] = {.lex_state = 63, .external_lex_state = 2},
-  [264] = {.lex_state = 63, .external_lex_state = 2},
-  [265] = {.lex_state = 63, .external_lex_state = 3},
-  [266] = {.lex_state = 63, .external_lex_state = 2},
-  [267] = {.lex_state = 63, .external_lex_state = 2},
-  [268] = {.lex_state = 63, .external_lex_state = 2},
-  [269] = {.lex_state = 63, .external_lex_state = 2},
-  [270] = {.lex_state = 63, .external_lex_state = 2},
-  [271] = {.lex_state = 63, .external_lex_state = 3},
-  [272] = {.lex_state = 63, .external_lex_state = 2},
-  [273] = {.lex_state = 63, .external_lex_state = 2},
-  [274] = {.lex_state = 63, .external_lex_state = 2},
-  [275] = {.lex_state = 63, .external_lex_state = 2},
-  [276] = {.lex_state = 63, .external_lex_state = 2},
-  [277] = {.lex_state = 63, .external_lex_state = 2},
-  [278] = {.lex_state = 63, .external_lex_state = 2},
-  [279] = {.lex_state = 63, .external_lex_state = 2},
-  [280] = {.lex_state = 63, .external_lex_state = 2},
-  [281] = {.lex_state = 63, .external_lex_state = 2},
-  [282] = {.lex_state = 63, .external_lex_state = 2},
-  [283] = {.lex_state = 63, .external_lex_state = 2},
-  [284] = {.lex_state = 63, .external_lex_state = 2},
-  [285] = {.lex_state = 63, .external_lex_state = 2},
-  [286] = {.lex_state = 63, .external_lex_state = 2},
-  [287] = {.lex_state = 63, .external_lex_state = 3},
-  [288] = {.lex_state = 63, .external_lex_state = 2},
-  [289] = {.lex_state = 63, .external_lex_state = 3},
-  [290] = {.lex_state = 63, .external_lex_state = 2},
-  [291] = {.lex_state = 63, .external_lex_state = 2},
-  [292] = {.lex_state = 63, .external_lex_state = 2},
-  [293] = {.lex_state = 63, .external_lex_state = 2},
-  [294] = {.lex_state = 63, .external_lex_state = 2},
-  [295] = {.lex_state = 63, .external_lex_state = 2},
-  [296] = {.lex_state = 63, .external_lex_state = 2},
-  [297] = {.lex_state = 63, .external_lex_state = 2},
-  [298] = {.lex_state = 63, .external_lex_state = 3},
-  [299] = {.lex_state = 63, .external_lex_state = 2},
-  [300] = {.lex_state = 63, .external_lex_state = 2},
-  [301] = {.lex_state = 63, .external_lex_state = 2},
-  [302] = {.lex_state = 63, .external_lex_state = 2},
-  [303] = {.lex_state = 63, .external_lex_state = 2},
-  [304] = {.lex_state = 63, .external_lex_state = 2},
-  [305] = {.lex_state = 63, .external_lex_state = 2},
-  [306] = {.lex_state = 63, .external_lex_state = 2},
-  [307] = {.lex_state = 63, .external_lex_state = 2},
-  [308] = {.lex_state = 63, .external_lex_state = 2},
-  [309] = {.lex_state = 63, .external_lex_state = 2},
-  [310] = {.lex_state = 63, .external_lex_state = 2},
-  [311] = {.lex_state = 63, .external_lex_state = 2},
-  [312] = {.lex_state = 63, .external_lex_state = 2},
-  [313] = {.lex_state = 63, .external_lex_state = 2},
-  [314] = {.lex_state = 63, .external_lex_state = 2},
-  [315] = {.lex_state = 63, .external_lex_state = 2},
-  [316] = {.lex_state = 63, .external_lex_state = 2},
-  [317] = {.lex_state = 63, .external_lex_state = 2},
-  [318] = {.lex_state = 63, .external_lex_state = 2},
-  [319] = {.lex_state = 63, .external_lex_state = 3},
-  [320] = {.lex_state = 63, .external_lex_state = 3},
-  [321] = {.lex_state = 63, .external_lex_state = 3},
-  [322] = {.lex_state = 63, .external_lex_state = 2},
-  [323] = {.lex_state = 63, .external_lex_state = 2},
-  [324] = {.lex_state = 63, .external_lex_state = 2},
-  [325] = {.lex_state = 63, .external_lex_state = 2},
-  [326] = {.lex_state = 63, .external_lex_state = 2},
-  [327] = {.lex_state = 63, .external_lex_state = 2},
-  [328] = {.lex_state = 63, .external_lex_state = 2},
-  [329] = {.lex_state = 63, .external_lex_state = 2},
-  [330] = {.lex_state = 63, .external_lex_state = 2},
-  [331] = {.lex_state = 63, .external_lex_state = 2},
-  [332] = {.lex_state = 63, .external_lex_state = 2},
-  [333] = {.lex_state = 63, .external_lex_state = 2},
-  [334] = {.lex_state = 63, .external_lex_state = 2},
-  [335] = {.lex_state = 63, .external_lex_state = 2},
-  [336] = {.lex_state = 63, .external_lex_state = 2},
-  [337] = {.lex_state = 63, .external_lex_state = 2},
-  [338] = {.lex_state = 63, .external_lex_state = 2},
-  [339] = {.lex_state = 63, .external_lex_state = 2},
-  [340] = {.lex_state = 63, .external_lex_state = 2},
-  [341] = {.lex_state = 63, .external_lex_state = 2},
-  [342] = {.lex_state = 63, .external_lex_state = 3},
-  [343] = {.lex_state = 63, .external_lex_state = 2},
-  [344] = {.lex_state = 63, .external_lex_state = 3},
-  [345] = {.lex_state = 63, .external_lex_state = 3},
-  [346] = {.lex_state = 63, .external_lex_state = 2},
-  [347] = {.lex_state = 63, .external_lex_state = 3},
-  [348] = {.lex_state = 63, .external_lex_state = 2},
-  [349] = {.lex_state = 63, .external_lex_state = 2},
-  [350] = {.lex_state = 63, .external_lex_state = 2},
-  [351] = {.lex_state = 63, .external_lex_state = 2},
-  [352] = {.lex_state = 63, .external_lex_state = 2},
-  [353] = {.lex_state = 63, .external_lex_state = 2},
-  [354] = {.lex_state = 63, .external_lex_state = 2},
-  [355] = {.lex_state = 63, .external_lex_state = 2},
-  [356] = {.lex_state = 63, .external_lex_state = 2},
-  [357] = {.lex_state = 63, .external_lex_state = 2},
-  [358] = {.lex_state = 63, .external_lex_state = 2},
-  [359] = {.lex_state = 63, .external_lex_state = 2},
-  [360] = {.lex_state = 63, .external_lex_state = 2},
-  [361] = {.lex_state = 63, .external_lex_state = 2},
-  [362] = {.lex_state = 63, .external_lex_state = 2},
-  [363] = {.lex_state = 63, .external_lex_state = 2},
-  [364] = {.lex_state = 63, .external_lex_state = 2},
-  [365] = {.lex_state = 63, .external_lex_state = 2},
-  [366] = {.lex_state = 63, .external_lex_state = 2},
-  [367] = {.lex_state = 63, .external_lex_state = 3},
-  [368] = {.lex_state = 63, .external_lex_state = 2},
-  [369] = {.lex_state = 63, .external_lex_state = 2},
-  [370] = {.lex_state = 63, .external_lex_state = 2},
-  [371] = {.lex_state = 63, .external_lex_state = 2},
-  [372] = {.lex_state = 63, .external_lex_state = 2},
-  [373] = {.lex_state = 63, .external_lex_state = 2},
-  [374] = {.lex_state = 63, .external_lex_state = 3},
-  [375] = {.lex_state = 63, .external_lex_state = 2},
-  [376] = {.lex_state = 63, .external_lex_state = 3},
-  [377] = {.lex_state = 63, .external_lex_state = 2},
-  [378] = {.lex_state = 63, .external_lex_state = 3},
-  [379] = {.lex_state = 63, .external_lex_state = 3},
-  [380] = {.lex_state = 63, .external_lex_state = 3},
-  [381] = {.lex_state = 63, .external_lex_state = 2},
-  [382] = {.lex_state = 63, .external_lex_state = 2},
-  [383] = {.lex_state = 63, .external_lex_state = 3},
-  [384] = {.lex_state = 63, .external_lex_state = 2},
-  [385] = {.lex_state = 63, .external_lex_state = 3},
-  [386] = {.lex_state = 63, .external_lex_state = 3},
-  [387] = {.lex_state = 63, .external_lex_state = 2},
-  [388] = {.lex_state = 63, .external_lex_state = 3},
-  [389] = {.lex_state = 63, .external_lex_state = 2},
-  [390] = {.lex_state = 63, .external_lex_state = 3},
-  [391] = {.lex_state = 63, .external_lex_state = 2},
-  [392] = {.lex_state = 63, .external_lex_state = 2},
-  [393] = {.lex_state = 63, .external_lex_state = 3},
-  [394] = {.lex_state = 63, .external_lex_state = 2},
-  [395] = {.lex_state = 63, .external_lex_state = 3},
-  [396] = {.lex_state = 63, .external_lex_state = 3},
-  [397] = {.lex_state = 63, .external_lex_state = 3},
-  [398] = {.lex_state = 63, .external_lex_state = 2},
-  [399] = {.lex_state = 63, .external_lex_state = 3},
-  [400] = {.lex_state = 63, .external_lex_state = 2},
-  [401] = {.lex_state = 63, .external_lex_state = 3},
-  [402] = {.lex_state = 63, .external_lex_state = 3},
-  [403] = {.lex_state = 63, .external_lex_state = 3},
-  [404] = {.lex_state = 63, .external_lex_state = 3},
-  [405] = {.lex_state = 63, .external_lex_state = 2},
-  [406] = {.lex_state = 63, .external_lex_state = 2},
-  [407] = {.lex_state = 63, .external_lex_state = 2},
-  [408] = {.lex_state = 63, .external_lex_state = 2},
-  [409] = {.lex_state = 63, .external_lex_state = 2},
-  [410] = {.lex_state = 63, .external_lex_state = 3},
-  [411] = {.lex_state = 63, .external_lex_state = 2},
-  [412] = {.lex_state = 63, .external_lex_state = 3},
-  [413] = {.lex_state = 63, .external_lex_state = 2},
-  [414] = {.lex_state = 63, .external_lex_state = 2},
-  [415] = {.lex_state = 63, .external_lex_state = 3},
-  [416] = {.lex_state = 63, .external_lex_state = 3},
-  [417] = {.lex_state = 63, .external_lex_state = 2},
-  [418] = {.lex_state = 63, .external_lex_state = 2},
-  [419] = {.lex_state = 63, .external_lex_state = 2},
-  [420] = {.lex_state = 63, .external_lex_state = 2},
-  [421] = {.lex_state = 63, .external_lex_state = 2},
-  [422] = {.lex_state = 63, .external_lex_state = 2},
-  [423] = {.lex_state = 63, .external_lex_state = 2},
-  [424] = {.lex_state = 63, .external_lex_state = 3},
-  [425] = {.lex_state = 63, .external_lex_state = 2},
-  [426] = {.lex_state = 63, .external_lex_state = 2},
-  [427] = {.lex_state = 63, .external_lex_state = 2},
-  [428] = {.lex_state = 63, .external_lex_state = 3},
-  [429] = {.lex_state = 63, .external_lex_state = 3},
-  [430] = {.lex_state = 63, .external_lex_state = 2},
-  [431] = {.lex_state = 63, .external_lex_state = 2},
-  [432] = {.lex_state = 63, .external_lex_state = 2},
-  [433] = {.lex_state = 63, .external_lex_state = 2},
-  [434] = {.lex_state = 63, .external_lex_state = 2},
-  [435] = {.lex_state = 63, .external_lex_state = 2},
-  [436] = {.lex_state = 63, .external_lex_state = 2},
-  [437] = {.lex_state = 63, .external_lex_state = 2},
-  [438] = {.lex_state = 63, .external_lex_state = 2},
-  [439] = {.lex_state = 63, .external_lex_state = 3},
-  [440] = {.lex_state = 63, .external_lex_state = 2},
-  [441] = {.lex_state = 63, .external_lex_state = 2},
-  [442] = {.lex_state = 63, .external_lex_state = 2},
-  [443] = {.lex_state = 63, .external_lex_state = 2},
-  [444] = {.lex_state = 63, .external_lex_state = 2},
-  [445] = {.lex_state = 63, .external_lex_state = 2},
-  [446] = {.lex_state = 63, .external_lex_state = 2},
-  [447] = {.lex_state = 63, .external_lex_state = 2},
-  [448] = {.lex_state = 62, .external_lex_state = 4},
-  [449] = {.lex_state = 62, .external_lex_state = 4},
-  [450] = {.lex_state = 62, .external_lex_state = 4},
-  [451] = {.lex_state = 62, .external_lex_state = 4},
-  [452] = {.lex_state = 62, .external_lex_state = 4},
-  [453] = {.lex_state = 62, .external_lex_state = 4},
-  [454] = {.lex_state = 62, .external_lex_state = 4},
-  [455] = {.lex_state = 62, .external_lex_state = 4},
-  [456] = {.lex_state = 62, .external_lex_state = 4},
-  [457] = {.lex_state = 62, .external_lex_state = 4},
-  [458] = {.lex_state = 62, .external_lex_state = 4},
-  [459] = {.lex_state = 62, .external_lex_state = 4},
-  [460] = {.lex_state = 62, .external_lex_state = 4},
-  [461] = {.lex_state = 64, .external_lex_state = 4},
-  [462] = {.lex_state = 62, .external_lex_state = 4},
-  [463] = {.lex_state = 64, .external_lex_state = 4},
-  [464] = {.lex_state = 62, .external_lex_state = 5},
-  [465] = {.lex_state = 64, .external_lex_state = 4},
-  [466] = {.lex_state = 63, .external_lex_state = 2},
-  [467] = {.lex_state = 63, .external_lex_state = 2},
-  [468] = {.lex_state = 63, .external_lex_state = 2},
-  [469] = {.lex_state = 63, .external_lex_state = 2},
-  [470] = {.lex_state = 63, .external_lex_state = 2},
-  [471] = {.lex_state = 63, .external_lex_state = 2},
-  [472] = {.lex_state = 62, .external_lex_state = 5},
-  [473] = {.lex_state = 62, .external_lex_state = 4},
-  [474] = {.lex_state = 64, .external_lex_state = 4},
-  [475] = {.lex_state = 64, .external_lex_state = 4},
-  [476] = {.lex_state = 64, .external_lex_state = 4},
-  [477] = {.lex_state = 64, .external_lex_state = 4},
-  [478] = {.lex_state = 64, .external_lex_state = 4},
-  [479] = {.lex_state = 62, .external_lex_state = 4},
-  [480] = {.lex_state = 64, .external_lex_state = 4},
-  [481] = {.lex_state = 64, .external_lex_state = 4},
-  [482] = {.lex_state = 64, .external_lex_state = 4},
-  [483] = {.lex_state = 64, .external_lex_state = 4},
-  [484] = {.lex_state = 64, .external_lex_state = 4},
-  [485] = {.lex_state = 64, .external_lex_state = 4},
-  [486] = {.lex_state = 64, .external_lex_state = 4},
-  [487] = {.lex_state = 64, .external_lex_state = 4},
-  [488] = {.lex_state = 64, .external_lex_state = 4},
-  [489] = {.lex_state = 64, .external_lex_state = 4},
-  [490] = {.lex_state = 64, .external_lex_state = 4},
-  [491] = {.lex_state = 62, .external_lex_state = 4},
-  [492] = {.lex_state = 64, .external_lex_state = 4},
-  [493] = {.lex_state = 64, .external_lex_state = 4},
-  [494] = {.lex_state = 64, .external_lex_state = 4},
-  [495] = {.lex_state = 64, .external_lex_state = 4},
-  [496] = {.lex_state = 64, .external_lex_state = 4},
-  [497] = {.lex_state = 64, .external_lex_state = 4},
-  [498] = {.lex_state = 64, .external_lex_state = 4},
-  [499] = {.lex_state = 62, .external_lex_state = 5},
-  [500] = {.lex_state = 62, .external_lex_state = 5},
-  [501] = {.lex_state = 64, .external_lex_state = 4},
-  [502] = {.lex_state = 64, .external_lex_state = 4},
-  [503] = {.lex_state = 64, .external_lex_state = 4},
-  [504] = {.lex_state = 64, .external_lex_state = 4},
-  [505] = {.lex_state = 64, .external_lex_state = 4},
-  [506] = {.lex_state = 64, .external_lex_state = 4},
-  [507] = {.lex_state = 64, .external_lex_state = 4},
-  [508] = {.lex_state = 64, .external_lex_state = 4},
-  [509] = {.lex_state = 64, .external_lex_state = 4},
-  [510] = {.lex_state = 62, .external_lex_state = 4},
-  [511] = {.lex_state = 62, .external_lex_state = 5},
-  [512] = {.lex_state = 62, .external_lex_state = 4},
-  [513] = {.lex_state = 62, .external_lex_state = 4},
-  [514] = {.lex_state = 62, .external_lex_state = 4},
-  [515] = {.lex_state = 62, .external_lex_state = 4},
-  [516] = {.lex_state = 62, .external_lex_state = 4},
-  [517] = {.lex_state = 62, .external_lex_state = 4},
-  [518] = {.lex_state = 62, .external_lex_state = 4},
-  [519] = {.lex_state = 62, .external_lex_state = 4},
-  [520] = {.lex_state = 64, .external_lex_state = 4},
-  [521] = {.lex_state = 64, .external_lex_state = 4},
-  [522] = {.lex_state = 64, .external_lex_state = 4},
-  [523] = {.lex_state = 64, .external_lex_state = 4},
-  [524] = {.lex_state = 62, .external_lex_state = 5},
-  [525] = {.lex_state = 62, .external_lex_state = 5},
-  [526] = {.lex_state = 62, .external_lex_state = 5},
-  [527] = {.lex_state = 62, .external_lex_state = 5},
-  [528] = {.lex_state = 62, .external_lex_state = 5},
-  [529] = {.lex_state = 62, .external_lex_state = 5},
-  [530] = {.lex_state = 62, .external_lex_state = 5},
-  [531] = {.lex_state = 62, .external_lex_state = 5},
-  [532] = {.lex_state = 62, .external_lex_state = 2},
-  [533] = {.lex_state = 62, .external_lex_state = 2},
-  [534] = {.lex_state = 62, .external_lex_state = 2},
-  [535] = {.lex_state = 62, .external_lex_state = 2},
-  [536] = {.lex_state = 62, .external_lex_state = 2},
-  [537] = {.lex_state = 62, .external_lex_state = 2},
-  [538] = {.lex_state = 62, .external_lex_state = 2},
-  [539] = {.lex_state = 62, .external_lex_state = 2},
-  [540] = {.lex_state = 62, .external_lex_state = 2},
-  [541] = {.lex_state = 62, .external_lex_state = 2},
-  [542] = {.lex_state = 62, .external_lex_state = 2},
-  [543] = {.lex_state = 62, .external_lex_state = 2},
-  [544] = {.lex_state = 62, .external_lex_state = 2},
+  [77] = {.lex_state = 73, .external_lex_state = 3},
+  [78] = {.lex_state = 73, .external_lex_state = 2},
+  [79] = {.lex_state = 73, .external_lex_state = 2},
+  [80] = {.lex_state = 73, .external_lex_state = 2},
+  [81] = {.lex_state = 73, .external_lex_state = 2},
+  [82] = {.lex_state = 73, .external_lex_state = 2},
+  [83] = {.lex_state = 73, .external_lex_state = 2},
+  [84] = {.lex_state = 73, .external_lex_state = 2},
+  [85] = {.lex_state = 73, .external_lex_state = 2},
+  [86] = {.lex_state = 73, .external_lex_state = 2},
+  [87] = {.lex_state = 73, .external_lex_state = 2},
+  [88] = {.lex_state = 73, .external_lex_state = 2},
+  [89] = {.lex_state = 73, .external_lex_state = 2},
+  [90] = {.lex_state = 73, .external_lex_state = 2},
+  [91] = {.lex_state = 73, .external_lex_state = 2},
+  [92] = {.lex_state = 73, .external_lex_state = 2},
+  [93] = {.lex_state = 73, .external_lex_state = 2},
+  [94] = {.lex_state = 73, .external_lex_state = 2},
+  [95] = {.lex_state = 73, .external_lex_state = 2},
+  [96] = {.lex_state = 73, .external_lex_state = 2},
+  [97] = {.lex_state = 73, .external_lex_state = 2},
+  [98] = {.lex_state = 73, .external_lex_state = 2},
+  [99] = {.lex_state = 73, .external_lex_state = 2},
+  [100] = {.lex_state = 73, .external_lex_state = 2},
+  [101] = {.lex_state = 73, .external_lex_state = 2},
+  [102] = {.lex_state = 73, .external_lex_state = 2},
+  [103] = {.lex_state = 73, .external_lex_state = 2},
+  [104] = {.lex_state = 73, .external_lex_state = 2},
+  [105] = {.lex_state = 73, .external_lex_state = 2},
+  [106] = {.lex_state = 73, .external_lex_state = 2},
+  [107] = {.lex_state = 73, .external_lex_state = 2},
+  [108] = {.lex_state = 73, .external_lex_state = 2},
+  [109] = {.lex_state = 73, .external_lex_state = 2},
+  [110] = {.lex_state = 73, .external_lex_state = 2},
+  [111] = {.lex_state = 73, .external_lex_state = 2},
+  [112] = {.lex_state = 73, .external_lex_state = 2},
+  [113] = {.lex_state = 73, .external_lex_state = 2},
+  [114] = {.lex_state = 73, .external_lex_state = 2},
+  [115] = {.lex_state = 73, .external_lex_state = 2},
+  [116] = {.lex_state = 73, .external_lex_state = 2},
+  [117] = {.lex_state = 73, .external_lex_state = 2},
+  [118] = {.lex_state = 73, .external_lex_state = 2},
+  [119] = {.lex_state = 73, .external_lex_state = 2},
+  [120] = {.lex_state = 73, .external_lex_state = 2},
+  [121] = {.lex_state = 0, .external_lex_state = 2},
+  [122] = {.lex_state = 0, .external_lex_state = 2},
+  [123] = {.lex_state = 0, .external_lex_state = 2},
+  [124] = {.lex_state = 0, .external_lex_state = 2},
+  [125] = {.lex_state = 0, .external_lex_state = 2},
+  [126] = {.lex_state = 0, .external_lex_state = 2},
+  [127] = {.lex_state = 73, .external_lex_state = 2},
+  [128] = {.lex_state = 0, .external_lex_state = 2},
+  [129] = {.lex_state = 0, .external_lex_state = 2},
+  [130] = {.lex_state = 0, .external_lex_state = 2},
+  [131] = {.lex_state = 73, .external_lex_state = 2},
+  [132] = {.lex_state = 0, .external_lex_state = 2},
+  [133] = {.lex_state = 73, .external_lex_state = 2},
+  [134] = {.lex_state = 0, .external_lex_state = 2},
+  [135] = {.lex_state = 0, .external_lex_state = 2},
+  [136] = {.lex_state = 0, .external_lex_state = 2},
+  [137] = {.lex_state = 73, .external_lex_state = 2},
+  [138] = {.lex_state = 0, .external_lex_state = 2},
+  [139] = {.lex_state = 0, .external_lex_state = 2},
+  [140] = {.lex_state = 73, .external_lex_state = 2},
+  [141] = {.lex_state = 0, .external_lex_state = 2},
+  [142] = {.lex_state = 0, .external_lex_state = 2},
+  [143] = {.lex_state = 73, .external_lex_state = 2},
+  [144] = {.lex_state = 0, .external_lex_state = 2},
+  [145] = {.lex_state = 0, .external_lex_state = 2},
+  [146] = {.lex_state = 0, .external_lex_state = 2},
+  [147] = {.lex_state = 0, .external_lex_state = 2},
+  [148] = {.lex_state = 0, .external_lex_state = 2},
+  [149] = {.lex_state = 0, .external_lex_state = 2},
+  [150] = {.lex_state = 0, .external_lex_state = 2},
+  [151] = {.lex_state = 0, .external_lex_state = 2},
+  [152] = {.lex_state = 0, .external_lex_state = 2},
+  [153] = {.lex_state = 0, .external_lex_state = 2},
+  [154] = {.lex_state = 0, .external_lex_state = 2},
+  [155] = {.lex_state = 0, .external_lex_state = 2},
+  [156] = {.lex_state = 0, .external_lex_state = 2},
+  [157] = {.lex_state = 0, .external_lex_state = 2},
+  [158] = {.lex_state = 0, .external_lex_state = 2},
+  [159] = {.lex_state = 0, .external_lex_state = 2},
+  [160] = {.lex_state = 0, .external_lex_state = 2},
+  [161] = {.lex_state = 0, .external_lex_state = 2},
+  [162] = {.lex_state = 0, .external_lex_state = 2},
+  [163] = {.lex_state = 0, .external_lex_state = 2},
+  [164] = {.lex_state = 0, .external_lex_state = 2},
+  [165] = {.lex_state = 0, .external_lex_state = 2},
+  [166] = {.lex_state = 0, .external_lex_state = 2},
+  [167] = {.lex_state = 0, .external_lex_state = 2},
+  [168] = {.lex_state = 0, .external_lex_state = 2},
+  [169] = {.lex_state = 0, .external_lex_state = 2},
+  [170] = {.lex_state = 0, .external_lex_state = 2},
+  [171] = {.lex_state = 0, .external_lex_state = 2},
+  [172] = {.lex_state = 0, .external_lex_state = 2},
+  [173] = {.lex_state = 0, .external_lex_state = 2},
+  [174] = {.lex_state = 0, .external_lex_state = 2},
+  [175] = {.lex_state = 0, .external_lex_state = 2},
+  [176] = {.lex_state = 0, .external_lex_state = 2},
+  [177] = {.lex_state = 0, .external_lex_state = 2},
+  [178] = {.lex_state = 0, .external_lex_state = 2},
+  [179] = {.lex_state = 0, .external_lex_state = 2},
+  [180] = {.lex_state = 0, .external_lex_state = 2},
+  [181] = {.lex_state = 0, .external_lex_state = 2},
+  [182] = {.lex_state = 0, .external_lex_state = 2},
+  [183] = {.lex_state = 0, .external_lex_state = 2},
+  [184] = {.lex_state = 0, .external_lex_state = 2},
+  [185] = {.lex_state = 0, .external_lex_state = 2},
+  [186] = {.lex_state = 0, .external_lex_state = 2},
+  [187] = {.lex_state = 0, .external_lex_state = 2},
+  [188] = {.lex_state = 0, .external_lex_state = 2},
+  [189] = {.lex_state = 0, .external_lex_state = 2},
+  [190] = {.lex_state = 0, .external_lex_state = 2},
+  [191] = {.lex_state = 0, .external_lex_state = 2},
+  [192] = {.lex_state = 0, .external_lex_state = 2},
+  [193] = {.lex_state = 0, .external_lex_state = 2},
+  [194] = {.lex_state = 0, .external_lex_state = 2},
+  [195] = {.lex_state = 0, .external_lex_state = 2},
+  [196] = {.lex_state = 0, .external_lex_state = 2},
+  [197] = {.lex_state = 0, .external_lex_state = 2},
+  [198] = {.lex_state = 0, .external_lex_state = 2},
+  [199] = {.lex_state = 0, .external_lex_state = 2},
+  [200] = {.lex_state = 0, .external_lex_state = 2},
+  [201] = {.lex_state = 0, .external_lex_state = 2},
+  [202] = {.lex_state = 0, .external_lex_state = 2},
+  [203] = {.lex_state = 0, .external_lex_state = 2},
+  [204] = {.lex_state = 0, .external_lex_state = 2},
+  [205] = {.lex_state = 0, .external_lex_state = 2},
+  [206] = {.lex_state = 0, .external_lex_state = 2},
+  [207] = {.lex_state = 0, .external_lex_state = 2},
+  [208] = {.lex_state = 0, .external_lex_state = 2},
+  [209] = {.lex_state = 0, .external_lex_state = 2},
+  [210] = {.lex_state = 0, .external_lex_state = 2},
+  [211] = {.lex_state = 0, .external_lex_state = 2},
+  [212] = {.lex_state = 0, .external_lex_state = 2},
+  [213] = {.lex_state = 73, .external_lex_state = 3},
+  [214] = {.lex_state = 73, .external_lex_state = 3},
+  [215] = {.lex_state = 73, .external_lex_state = 2},
+  [216] = {.lex_state = 73, .external_lex_state = 2},
+  [217] = {.lex_state = 73, .external_lex_state = 2},
+  [218] = {.lex_state = 73, .external_lex_state = 2},
+  [219] = {.lex_state = 73, .external_lex_state = 2},
+  [220] = {.lex_state = 73, .external_lex_state = 2},
+  [221] = {.lex_state = 73, .external_lex_state = 3},
+  [222] = {.lex_state = 73, .external_lex_state = 3},
+  [223] = {.lex_state = 73, .external_lex_state = 2},
+  [224] = {.lex_state = 73, .external_lex_state = 2},
+  [225] = {.lex_state = 73, .external_lex_state = 2},
+  [226] = {.lex_state = 73, .external_lex_state = 2},
+  [227] = {.lex_state = 73, .external_lex_state = 2},
+  [228] = {.lex_state = 73, .external_lex_state = 2},
+  [229] = {.lex_state = 73, .external_lex_state = 2},
+  [230] = {.lex_state = 73, .external_lex_state = 2},
+  [231] = {.lex_state = 73, .external_lex_state = 3},
+  [232] = {.lex_state = 73, .external_lex_state = 3},
+  [233] = {.lex_state = 73, .external_lex_state = 2},
+  [234] = {.lex_state = 73, .external_lex_state = 2},
+  [235] = {.lex_state = 73, .external_lex_state = 2},
+  [236] = {.lex_state = 73, .external_lex_state = 2},
+  [237] = {.lex_state = 73, .external_lex_state = 2},
+  [238] = {.lex_state = 73, .external_lex_state = 2},
+  [239] = {.lex_state = 73, .external_lex_state = 2},
+  [240] = {.lex_state = 73, .external_lex_state = 2},
+  [241] = {.lex_state = 73, .external_lex_state = 2},
+  [242] = {.lex_state = 73, .external_lex_state = 2},
+  [243] = {.lex_state = 73, .external_lex_state = 2},
+  [244] = {.lex_state = 73, .external_lex_state = 2},
+  [245] = {.lex_state = 73, .external_lex_state = 2},
+  [246] = {.lex_state = 73, .external_lex_state = 2},
+  [247] = {.lex_state = 73, .external_lex_state = 2},
+  [248] = {.lex_state = 73, .external_lex_state = 3},
+  [249] = {.lex_state = 73, .external_lex_state = 2},
+  [250] = {.lex_state = 73, .external_lex_state = 2},
+  [251] = {.lex_state = 73, .external_lex_state = 2},
+  [252] = {.lex_state = 73, .external_lex_state = 2},
+  [253] = {.lex_state = 73, .external_lex_state = 2},
+  [254] = {.lex_state = 73, .external_lex_state = 2},
+  [255] = {.lex_state = 73, .external_lex_state = 2},
+  [256] = {.lex_state = 73, .external_lex_state = 2},
+  [257] = {.lex_state = 73, .external_lex_state = 2},
+  [258] = {.lex_state = 73, .external_lex_state = 2},
+  [259] = {.lex_state = 73, .external_lex_state = 2},
+  [260] = {.lex_state = 73, .external_lex_state = 2},
+  [261] = {.lex_state = 73, .external_lex_state = 2},
+  [262] = {.lex_state = 73, .external_lex_state = 2},
+  [263] = {.lex_state = 73, .external_lex_state = 2},
+  [264] = {.lex_state = 73, .external_lex_state = 2},
+  [265] = {.lex_state = 73, .external_lex_state = 3},
+  [266] = {.lex_state = 73, .external_lex_state = 2},
+  [267] = {.lex_state = 73, .external_lex_state = 2},
+  [268] = {.lex_state = 73, .external_lex_state = 2},
+  [269] = {.lex_state = 73, .external_lex_state = 2},
+  [270] = {.lex_state = 73, .external_lex_state = 2},
+  [271] = {.lex_state = 73, .external_lex_state = 3},
+  [272] = {.lex_state = 73, .external_lex_state = 2},
+  [273] = {.lex_state = 73, .external_lex_state = 2},
+  [274] = {.lex_state = 73, .external_lex_state = 2},
+  [275] = {.lex_state = 73, .external_lex_state = 2},
+  [276] = {.lex_state = 73, .external_lex_state = 2},
+  [277] = {.lex_state = 73, .external_lex_state = 2},
+  [278] = {.lex_state = 73, .external_lex_state = 2},
+  [279] = {.lex_state = 73, .external_lex_state = 2},
+  [280] = {.lex_state = 73, .external_lex_state = 2},
+  [281] = {.lex_state = 73, .external_lex_state = 2},
+  [282] = {.lex_state = 73, .external_lex_state = 2},
+  [283] = {.lex_state = 73, .external_lex_state = 2},
+  [284] = {.lex_state = 73, .external_lex_state = 2},
+  [285] = {.lex_state = 73, .external_lex_state = 2},
+  [286] = {.lex_state = 73, .external_lex_state = 2},
+  [287] = {.lex_state = 73, .external_lex_state = 3},
+  [288] = {.lex_state = 73, .external_lex_state = 2},
+  [289] = {.lex_state = 73, .external_lex_state = 3},
+  [290] = {.lex_state = 73, .external_lex_state = 2},
+  [291] = {.lex_state = 73, .external_lex_state = 2},
+  [292] = {.lex_state = 73, .external_lex_state = 2},
+  [293] = {.lex_state = 73, .external_lex_state = 2},
+  [294] = {.lex_state = 73, .external_lex_state = 2},
+  [295] = {.lex_state = 73, .external_lex_state = 2},
+  [296] = {.lex_state = 73, .external_lex_state = 2},
+  [297] = {.lex_state = 73, .external_lex_state = 2},
+  [298] = {.lex_state = 73, .external_lex_state = 3},
+  [299] = {.lex_state = 73, .external_lex_state = 2},
+  [300] = {.lex_state = 73, .external_lex_state = 2},
+  [301] = {.lex_state = 73, .external_lex_state = 2},
+  [302] = {.lex_state = 73, .external_lex_state = 2},
+  [303] = {.lex_state = 73, .external_lex_state = 2},
+  [304] = {.lex_state = 73, .external_lex_state = 2},
+  [305] = {.lex_state = 73, .external_lex_state = 2},
+  [306] = {.lex_state = 73, .external_lex_state = 2},
+  [307] = {.lex_state = 73, .external_lex_state = 2},
+  [308] = {.lex_state = 73, .external_lex_state = 2},
+  [309] = {.lex_state = 73, .external_lex_state = 2},
+  [310] = {.lex_state = 73, .external_lex_state = 2},
+  [311] = {.lex_state = 73, .external_lex_state = 2},
+  [312] = {.lex_state = 73, .external_lex_state = 2},
+  [313] = {.lex_state = 73, .external_lex_state = 2},
+  [314] = {.lex_state = 73, .external_lex_state = 2},
+  [315] = {.lex_state = 73, .external_lex_state = 2},
+  [316] = {.lex_state = 73, .external_lex_state = 2},
+  [317] = {.lex_state = 73, .external_lex_state = 2},
+  [318] = {.lex_state = 73, .external_lex_state = 2},
+  [319] = {.lex_state = 73, .external_lex_state = 3},
+  [320] = {.lex_state = 73, .external_lex_state = 3},
+  [321] = {.lex_state = 73, .external_lex_state = 3},
+  [322] = {.lex_state = 73, .external_lex_state = 2},
+  [323] = {.lex_state = 73, .external_lex_state = 2},
+  [324] = {.lex_state = 73, .external_lex_state = 2},
+  [325] = {.lex_state = 73, .external_lex_state = 2},
+  [326] = {.lex_state = 73, .external_lex_state = 2},
+  [327] = {.lex_state = 73, .external_lex_state = 2},
+  [328] = {.lex_state = 73, .external_lex_state = 2},
+  [329] = {.lex_state = 73, .external_lex_state = 2},
+  [330] = {.lex_state = 73, .external_lex_state = 2},
+  [331] = {.lex_state = 73, .external_lex_state = 2},
+  [332] = {.lex_state = 73, .external_lex_state = 2},
+  [333] = {.lex_state = 73, .external_lex_state = 2},
+  [334] = {.lex_state = 73, .external_lex_state = 2},
+  [335] = {.lex_state = 73, .external_lex_state = 2},
+  [336] = {.lex_state = 73, .external_lex_state = 2},
+  [337] = {.lex_state = 73, .external_lex_state = 2},
+  [338] = {.lex_state = 73, .external_lex_state = 2},
+  [339] = {.lex_state = 73, .external_lex_state = 2},
+  [340] = {.lex_state = 73, .external_lex_state = 2},
+  [341] = {.lex_state = 73, .external_lex_state = 2},
+  [342] = {.lex_state = 73, .external_lex_state = 3},
+  [343] = {.lex_state = 73, .external_lex_state = 2},
+  [344] = {.lex_state = 73, .external_lex_state = 3},
+  [345] = {.lex_state = 73, .external_lex_state = 3},
+  [346] = {.lex_state = 73, .external_lex_state = 2},
+  [347] = {.lex_state = 73, .external_lex_state = 3},
+  [348] = {.lex_state = 73, .external_lex_state = 2},
+  [349] = {.lex_state = 73, .external_lex_state = 2},
+  [350] = {.lex_state = 73, .external_lex_state = 2},
+  [351] = {.lex_state = 73, .external_lex_state = 2},
+  [352] = {.lex_state = 73, .external_lex_state = 2},
+  [353] = {.lex_state = 73, .external_lex_state = 2},
+  [354] = {.lex_state = 73, .external_lex_state = 2},
+  [355] = {.lex_state = 73, .external_lex_state = 2},
+  [356] = {.lex_state = 73, .external_lex_state = 2},
+  [357] = {.lex_state = 73, .external_lex_state = 2},
+  [358] = {.lex_state = 73, .external_lex_state = 2},
+  [359] = {.lex_state = 73, .external_lex_state = 2},
+  [360] = {.lex_state = 73, .external_lex_state = 2},
+  [361] = {.lex_state = 73, .external_lex_state = 2},
+  [362] = {.lex_state = 73, .external_lex_state = 2},
+  [363] = {.lex_state = 73, .external_lex_state = 2},
+  [364] = {.lex_state = 73, .external_lex_state = 2},
+  [365] = {.lex_state = 73, .external_lex_state = 2},
+  [366] = {.lex_state = 73, .external_lex_state = 2},
+  [367] = {.lex_state = 73, .external_lex_state = 3},
+  [368] = {.lex_state = 73, .external_lex_state = 2},
+  [369] = {.lex_state = 73, .external_lex_state = 2},
+  [370] = {.lex_state = 73, .external_lex_state = 2},
+  [371] = {.lex_state = 73, .external_lex_state = 2},
+  [372] = {.lex_state = 73, .external_lex_state = 2},
+  [373] = {.lex_state = 73, .external_lex_state = 2},
+  [374] = {.lex_state = 73, .external_lex_state = 3},
+  [375] = {.lex_state = 73, .external_lex_state = 2},
+  [376] = {.lex_state = 73, .external_lex_state = 3},
+  [377] = {.lex_state = 73, .external_lex_state = 2},
+  [378] = {.lex_state = 73, .external_lex_state = 3},
+  [379] = {.lex_state = 73, .external_lex_state = 3},
+  [380] = {.lex_state = 73, .external_lex_state = 3},
+  [381] = {.lex_state = 73, .external_lex_state = 2},
+  [382] = {.lex_state = 73, .external_lex_state = 2},
+  [383] = {.lex_state = 73, .external_lex_state = 3},
+  [384] = {.lex_state = 73, .external_lex_state = 2},
+  [385] = {.lex_state = 73, .external_lex_state = 3},
+  [386] = {.lex_state = 73, .external_lex_state = 3},
+  [387] = {.lex_state = 73, .external_lex_state = 2},
+  [388] = {.lex_state = 73, .external_lex_state = 3},
+  [389] = {.lex_state = 73, .external_lex_state = 2},
+  [390] = {.lex_state = 73, .external_lex_state = 3},
+  [391] = {.lex_state = 73, .external_lex_state = 2},
+  [392] = {.lex_state = 73, .external_lex_state = 2},
+  [393] = {.lex_state = 73, .external_lex_state = 3},
+  [394] = {.lex_state = 73, .external_lex_state = 2},
+  [395] = {.lex_state = 73, .external_lex_state = 3},
+  [396] = {.lex_state = 73, .external_lex_state = 3},
+  [397] = {.lex_state = 73, .external_lex_state = 3},
+  [398] = {.lex_state = 73, .external_lex_state = 2},
+  [399] = {.lex_state = 73, .external_lex_state = 3},
+  [400] = {.lex_state = 73, .external_lex_state = 2},
+  [401] = {.lex_state = 73, .external_lex_state = 3},
+  [402] = {.lex_state = 73, .external_lex_state = 3},
+  [403] = {.lex_state = 73, .external_lex_state = 3},
+  [404] = {.lex_state = 73, .external_lex_state = 3},
+  [405] = {.lex_state = 73, .external_lex_state = 2},
+  [406] = {.lex_state = 73, .external_lex_state = 2},
+  [407] = {.lex_state = 73, .external_lex_state = 2},
+  [408] = {.lex_state = 73, .external_lex_state = 2},
+  [409] = {.lex_state = 73, .external_lex_state = 2},
+  [410] = {.lex_state = 73, .external_lex_state = 3},
+  [411] = {.lex_state = 73, .external_lex_state = 2},
+  [412] = {.lex_state = 73, .external_lex_state = 3},
+  [413] = {.lex_state = 73, .external_lex_state = 2},
+  [414] = {.lex_state = 73, .external_lex_state = 2},
+  [415] = {.lex_state = 73, .external_lex_state = 3},
+  [416] = {.lex_state = 73, .external_lex_state = 3},
+  [417] = {.lex_state = 73, .external_lex_state = 2},
+  [418] = {.lex_state = 73, .external_lex_state = 2},
+  [419] = {.lex_state = 73, .external_lex_state = 2},
+  [420] = {.lex_state = 73, .external_lex_state = 2},
+  [421] = {.lex_state = 73, .external_lex_state = 2},
+  [422] = {.lex_state = 73, .external_lex_state = 2},
+  [423] = {.lex_state = 73, .external_lex_state = 2},
+  [424] = {.lex_state = 73, .external_lex_state = 3},
+  [425] = {.lex_state = 73, .external_lex_state = 2},
+  [426] = {.lex_state = 73, .external_lex_state = 2},
+  [427] = {.lex_state = 73, .external_lex_state = 2},
+  [428] = {.lex_state = 73, .external_lex_state = 3},
+  [429] = {.lex_state = 73, .external_lex_state = 3},
+  [430] = {.lex_state = 73, .external_lex_state = 2},
+  [431] = {.lex_state = 73, .external_lex_state = 2},
+  [432] = {.lex_state = 73, .external_lex_state = 2},
+  [433] = {.lex_state = 73, .external_lex_state = 2},
+  [434] = {.lex_state = 73, .external_lex_state = 2},
+  [435] = {.lex_state = 73, .external_lex_state = 2},
+  [436] = {.lex_state = 73, .external_lex_state = 2},
+  [437] = {.lex_state = 73, .external_lex_state = 2},
+  [438] = {.lex_state = 73, .external_lex_state = 2},
+  [439] = {.lex_state = 73, .external_lex_state = 3},
+  [440] = {.lex_state = 73, .external_lex_state = 2},
+  [441] = {.lex_state = 73, .external_lex_state = 2},
+  [442] = {.lex_state = 73, .external_lex_state = 2},
+  [443] = {.lex_state = 73, .external_lex_state = 2},
+  [444] = {.lex_state = 73, .external_lex_state = 2},
+  [445] = {.lex_state = 73, .external_lex_state = 2},
+  [446] = {.lex_state = 73, .external_lex_state = 2},
+  [447] = {.lex_state = 73, .external_lex_state = 2},
+  [448] = {.lex_state = 73, .external_lex_state = 4},
+  [449] = {.lex_state = 73, .external_lex_state = 4},
+  [450] = {.lex_state = 73, .external_lex_state = 4},
+  [451] = {.lex_state = 73, .external_lex_state = 4},
+  [452] = {.lex_state = 73, .external_lex_state = 4},
+  [453] = {.lex_state = 73, .external_lex_state = 4},
+  [454] = {.lex_state = 73, .external_lex_state = 4},
+  [455] = {.lex_state = 73, .external_lex_state = 4},
+  [456] = {.lex_state = 73, .external_lex_state = 4},
+  [457] = {.lex_state = 73, .external_lex_state = 4},
+  [458] = {.lex_state = 73, .external_lex_state = 4},
+  [459] = {.lex_state = 73, .external_lex_state = 4},
+  [460] = {.lex_state = 73, .external_lex_state = 4},
+  [461] = {.lex_state = 74, .external_lex_state = 4},
+  [462] = {.lex_state = 73, .external_lex_state = 4},
+  [463] = {.lex_state = 74, .external_lex_state = 4},
+  [464] = {.lex_state = 73, .external_lex_state = 5},
+  [465] = {.lex_state = 74, .external_lex_state = 4},
+  [466] = {.lex_state = 73, .external_lex_state = 2},
+  [467] = {.lex_state = 73, .external_lex_state = 2},
+  [468] = {.lex_state = 73, .external_lex_state = 2},
+  [469] = {.lex_state = 73, .external_lex_state = 2},
+  [470] = {.lex_state = 73, .external_lex_state = 2},
+  [471] = {.lex_state = 73, .external_lex_state = 2},
+  [472] = {.lex_state = 73, .external_lex_state = 5},
+  [473] = {.lex_state = 73, .external_lex_state = 4},
+  [474] = {.lex_state = 74, .external_lex_state = 4},
+  [475] = {.lex_state = 74, .external_lex_state = 4},
+  [476] = {.lex_state = 74, .external_lex_state = 4},
+  [477] = {.lex_state = 74, .external_lex_state = 4},
+  [478] = {.lex_state = 74, .external_lex_state = 4},
+  [479] = {.lex_state = 73, .external_lex_state = 4},
+  [480] = {.lex_state = 74, .external_lex_state = 4},
+  [481] = {.lex_state = 74, .external_lex_state = 4},
+  [482] = {.lex_state = 74, .external_lex_state = 4},
+  [483] = {.lex_state = 74, .external_lex_state = 4},
+  [484] = {.lex_state = 74, .external_lex_state = 4},
+  [485] = {.lex_state = 74, .external_lex_state = 4},
+  [486] = {.lex_state = 74, .external_lex_state = 4},
+  [487] = {.lex_state = 74, .external_lex_state = 4},
+  [488] = {.lex_state = 74, .external_lex_state = 4},
+  [489] = {.lex_state = 74, .external_lex_state = 4},
+  [490] = {.lex_state = 74, .external_lex_state = 4},
+  [491] = {.lex_state = 73, .external_lex_state = 4},
+  [492] = {.lex_state = 74, .external_lex_state = 4},
+  [493] = {.lex_state = 74, .external_lex_state = 4},
+  [494] = {.lex_state = 74, .external_lex_state = 4},
+  [495] = {.lex_state = 74, .external_lex_state = 4},
+  [496] = {.lex_state = 74, .external_lex_state = 4},
+  [497] = {.lex_state = 74, .external_lex_state = 4},
+  [498] = {.lex_state = 74, .external_lex_state = 4},
+  [499] = {.lex_state = 73, .external_lex_state = 5},
+  [500] = {.lex_state = 73, .external_lex_state = 5},
+  [501] = {.lex_state = 74, .external_lex_state = 4},
+  [502] = {.lex_state = 74, .external_lex_state = 4},
+  [503] = {.lex_state = 74, .external_lex_state = 4},
+  [504] = {.lex_state = 74, .external_lex_state = 4},
+  [505] = {.lex_state = 74, .external_lex_state = 4},
+  [506] = {.lex_state = 74, .external_lex_state = 4},
+  [507] = {.lex_state = 74, .external_lex_state = 4},
+  [508] = {.lex_state = 74, .external_lex_state = 4},
+  [509] = {.lex_state = 74, .external_lex_state = 4},
+  [510] = {.lex_state = 73, .external_lex_state = 4},
+  [511] = {.lex_state = 73, .external_lex_state = 5},
+  [512] = {.lex_state = 73, .external_lex_state = 4},
+  [513] = {.lex_state = 73, .external_lex_state = 4},
+  [514] = {.lex_state = 73, .external_lex_state = 4},
+  [515] = {.lex_state = 73, .external_lex_state = 4},
+  [516] = {.lex_state = 73, .external_lex_state = 4},
+  [517] = {.lex_state = 73, .external_lex_state = 4},
+  [518] = {.lex_state = 73, .external_lex_state = 4},
+  [519] = {.lex_state = 73, .external_lex_state = 4},
+  [520] = {.lex_state = 74, .external_lex_state = 4},
+  [521] = {.lex_state = 74, .external_lex_state = 4},
+  [522] = {.lex_state = 74, .external_lex_state = 4},
+  [523] = {.lex_state = 74, .external_lex_state = 4},
+  [524] = {.lex_state = 73, .external_lex_state = 5},
+  [525] = {.lex_state = 73, .external_lex_state = 5},
+  [526] = {.lex_state = 73, .external_lex_state = 5},
+  [527] = {.lex_state = 73, .external_lex_state = 5},
+  [528] = {.lex_state = 73, .external_lex_state = 5},
+  [529] = {.lex_state = 73, .external_lex_state = 5},
+  [530] = {.lex_state = 73, .external_lex_state = 5},
+  [531] = {.lex_state = 73, .external_lex_state = 5},
+  [532] = {.lex_state = 0, .external_lex_state = 2},
+  [533] = {.lex_state = 0, .external_lex_state = 2},
+  [534] = {.lex_state = 0, .external_lex_state = 2},
+  [535] = {.lex_state = 0, .external_lex_state = 2},
+  [536] = {.lex_state = 0, .external_lex_state = 2},
+  [537] = {.lex_state = 0, .external_lex_state = 2},
+  [538] = {.lex_state = 0, .external_lex_state = 2},
+  [539] = {.lex_state = 0, .external_lex_state = 2},
+  [540] = {.lex_state = 0, .external_lex_state = 2},
+  [541] = {.lex_state = 0, .external_lex_state = 2},
+  [542] = {.lex_state = 0, .external_lex_state = 2},
+  [543] = {.lex_state = 0, .external_lex_state = 2},
+  [544] = {.lex_state = 0, .external_lex_state = 2},
   [545] = {.lex_state = 3, .external_lex_state = 6},
   [546] = {.lex_state = 3, .external_lex_state = 6},
   [547] = {.lex_state = 3, .external_lex_state = 6},
@@ -4593,27 +4721,27 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [554] = {.lex_state = 3, .external_lex_state = 6},
   [555] = {.lex_state = 3, .external_lex_state = 6},
   [556] = {.lex_state = 3, .external_lex_state = 6},
-  [557] = {.lex_state = 64, .external_lex_state = 4},
-  [558] = {.lex_state = 64, .external_lex_state = 4},
-  [559] = {.lex_state = 64, .external_lex_state = 4},
-  [560] = {.lex_state = 64, .external_lex_state = 4},
-  [561] = {.lex_state = 64, .external_lex_state = 4},
-  [562] = {.lex_state = 64, .external_lex_state = 4},
+  [557] = {.lex_state = 74, .external_lex_state = 4},
+  [558] = {.lex_state = 74, .external_lex_state = 4},
+  [559] = {.lex_state = 74, .external_lex_state = 4},
+  [560] = {.lex_state = 74, .external_lex_state = 4},
+  [561] = {.lex_state = 74, .external_lex_state = 4},
+  [562] = {.lex_state = 74, .external_lex_state = 4},
   [563] = {.lex_state = 3, .external_lex_state = 6},
-  [564] = {.lex_state = 64, .external_lex_state = 4},
-  [565] = {.lex_state = 64, .external_lex_state = 4},
-  [566] = {.lex_state = 64, .external_lex_state = 4},
-  [567] = {.lex_state = 62, .external_lex_state = 4},
-  [568] = {.lex_state = 62, .external_lex_state = 4},
+  [564] = {.lex_state = 74, .external_lex_state = 4},
+  [565] = {.lex_state = 74, .external_lex_state = 4},
+  [566] = {.lex_state = 74, .external_lex_state = 4},
+  [567] = {.lex_state = 73, .external_lex_state = 4},
+  [568] = {.lex_state = 73, .external_lex_state = 4},
   [569] = {.lex_state = 1, .external_lex_state = 7},
   [570] = {.lex_state = 1, .external_lex_state = 7},
-  [571] = {.lex_state = 62, .external_lex_state = 4},
-  [572] = {.lex_state = 64, .external_lex_state = 4},
+  [571] = {.lex_state = 73, .external_lex_state = 4},
+  [572] = {.lex_state = 74, .external_lex_state = 4},
   [573] = {.lex_state = 1, .external_lex_state = 7},
-  [574] = {.lex_state = 64, .external_lex_state = 4},
+  [574] = {.lex_state = 74, .external_lex_state = 4},
   [575] = {.lex_state = 1, .external_lex_state = 7},
   [576] = {.lex_state = 1, .external_lex_state = 7},
-  [577] = {.lex_state = 64, .external_lex_state = 4},
+  [577] = {.lex_state = 74, .external_lex_state = 4},
   [578] = {.lex_state = 1, .external_lex_state = 7},
   [579] = {.lex_state = 1, .external_lex_state = 7},
   [580] = {.lex_state = 1, .external_lex_state = 7},
@@ -4621,15 +4749,15 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [582] = {.lex_state = 1, .external_lex_state = 7},
   [583] = {.lex_state = 1, .external_lex_state = 7},
   [584] = {.lex_state = 1, .external_lex_state = 7},
-  [585] = {.lex_state = 64, .external_lex_state = 4},
+  [585] = {.lex_state = 74, .external_lex_state = 4},
   [586] = {.lex_state = 1, .external_lex_state = 7},
-  [587] = {.lex_state = 64, .external_lex_state = 4},
-  [588] = {.lex_state = 64, .external_lex_state = 4},
+  [587] = {.lex_state = 74, .external_lex_state = 4},
+  [588] = {.lex_state = 74, .external_lex_state = 4},
   [589] = {.lex_state = 1, .external_lex_state = 7},
   [590] = {.lex_state = 1, .external_lex_state = 7},
   [591] = {.lex_state = 2, .external_lex_state = 8},
   [592] = {.lex_state = 2, .external_lex_state = 8},
-  [593] = {.lex_state = 62, .external_lex_state = 4},
+  [593] = {.lex_state = 73, .external_lex_state = 4},
   [594] = {.lex_state = 2, .external_lex_state = 8},
   [595] = {.lex_state = 2, .external_lex_state = 8},
   [596] = {.lex_state = 2, .external_lex_state = 8},
@@ -4646,7 +4774,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [607] = {.lex_state = 2, .external_lex_state = 8},
   [608] = {.lex_state = 1, .external_lex_state = 9},
   [609] = {.lex_state = 1, .external_lex_state = 9},
-  [610] = {.lex_state = 64, .external_lex_state = 4},
+  [610] = {.lex_state = 74, .external_lex_state = 4},
   [611] = {.lex_state = 3, .external_lex_state = 4},
   [612] = {.lex_state = 1, .external_lex_state = 9},
   [613] = {.lex_state = 0, .external_lex_state = 10},
@@ -4659,9 +4787,9 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [620] = {.lex_state = 1, .external_lex_state = 9},
   [621] = {.lex_state = 3, .external_lex_state = 4},
   [622] = {.lex_state = 3, .external_lex_state = 4},
-  [623] = {.lex_state = 64, .external_lex_state = 4},
+  [623] = {.lex_state = 74, .external_lex_state = 4},
   [624] = {.lex_state = 1, .external_lex_state = 9},
-  [625] = {.lex_state = 64, .external_lex_state = 4},
+  [625] = {.lex_state = 74, .external_lex_state = 4},
   [626] = {.lex_state = 0, .external_lex_state = 10},
   [627] = {.lex_state = 1, .external_lex_state = 9},
   [628] = {.lex_state = 0, .external_lex_state = 10},
@@ -4686,10 +4814,10 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [647] = {.lex_state = 2, .external_lex_state = 11},
   [648] = {.lex_state = 2, .external_lex_state = 11},
   [649] = {.lex_state = 2, .external_lex_state = 11},
-  [650] = {.lex_state = 64, .external_lex_state = 4},
-  [651] = {.lex_state = 64, .external_lex_state = 4},
+  [650] = {.lex_state = 74, .external_lex_state = 4},
+  [651] = {.lex_state = 74, .external_lex_state = 4},
   [652] = {.lex_state = 2, .external_lex_state = 11},
-  [653] = {.lex_state = 64, .external_lex_state = 4},
+  [653] = {.lex_state = 74, .external_lex_state = 4},
   [654] = {.lex_state = 2, .external_lex_state = 11},
   [655] = {.lex_state = 2, .external_lex_state = 11},
   [656] = {.lex_state = 2, .external_lex_state = 11},
@@ -4705,7 +4833,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [666] = {.lex_state = 2, .external_lex_state = 11},
   [667] = {.lex_state = 2, .external_lex_state = 11},
   [668] = {.lex_state = 2, .external_lex_state = 11},
-  [669] = {.lex_state = 64, .external_lex_state = 4},
+  [669] = {.lex_state = 74, .external_lex_state = 4},
   [670] = {.lex_state = 2, .external_lex_state = 11},
   [671] = {.lex_state = 0, .external_lex_state = 10},
   [672] = {.lex_state = 0, .external_lex_state = 10},
@@ -4717,13 +4845,13 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [678] = {.lex_state = 0, .external_lex_state = 10},
   [679] = {.lex_state = 2, .external_lex_state = 11},
   [680] = {.lex_state = 3, .external_lex_state = 6},
-  [681] = {.lex_state = 64, .external_lex_state = 4},
+  [681] = {.lex_state = 74, .external_lex_state = 4},
   [682] = {.lex_state = 2, .external_lex_state = 11},
   [683] = {.lex_state = 2, .external_lex_state = 11},
   [684] = {.lex_state = 2, .external_lex_state = 11},
-  [685] = {.lex_state = 64, .external_lex_state = 4},
+  [685] = {.lex_state = 74, .external_lex_state = 4},
   [686] = {.lex_state = 2, .external_lex_state = 11},
-  [687] = {.lex_state = 64, .external_lex_state = 4},
+  [687] = {.lex_state = 74, .external_lex_state = 4},
   [688] = {.lex_state = 2, .external_lex_state = 11},
   [689] = {.lex_state = 2, .external_lex_state = 11},
   [690] = {.lex_state = 2, .external_lex_state = 11},
@@ -4748,33 +4876,33 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [709] = {.lex_state = 4, .external_lex_state = 10},
   [710] = {.lex_state = 4, .external_lex_state = 4},
   [711] = {.lex_state = 4, .external_lex_state = 10},
-  [712] = {.lex_state = 62, .external_lex_state = 4},
+  [712] = {.lex_state = 73, .external_lex_state = 4},
   [713] = {.lex_state = 4, .external_lex_state = 10},
   [714] = {.lex_state = 1, .external_lex_state = 7},
   [715] = {.lex_state = 4, .external_lex_state = 4},
-  [716] = {.lex_state = 62, .external_lex_state = 4},
+  [716] = {.lex_state = 73, .external_lex_state = 4},
   [717] = {.lex_state = 4, .external_lex_state = 4},
   [718] = {.lex_state = 3, .external_lex_state = 6},
   [719] = {.lex_state = 3, .external_lex_state = 4},
-  [720] = {.lex_state = 62, .external_lex_state = 4},
-  [721] = {.lex_state = 62, .external_lex_state = 4},
-  [722] = {.lex_state = 64, .external_lex_state = 4},
+  [720] = {.lex_state = 73, .external_lex_state = 4},
+  [721] = {.lex_state = 73, .external_lex_state = 4},
+  [722] = {.lex_state = 74, .external_lex_state = 4},
   [723] = {.lex_state = 3, .external_lex_state = 4},
-  [724] = {.lex_state = 64, .external_lex_state = 4},
-  [725] = {.lex_state = 64, .external_lex_state = 4},
+  [724] = {.lex_state = 74, .external_lex_state = 4},
+  [725] = {.lex_state = 74, .external_lex_state = 4},
   [726] = {.lex_state = 3, .external_lex_state = 4},
-  [727] = {.lex_state = 64, .external_lex_state = 4},
+  [727] = {.lex_state = 74, .external_lex_state = 4},
   [728] = {.lex_state = 12, .external_lex_state = 4},
-  [729] = {.lex_state = 62, .external_lex_state = 4},
-  [730] = {.lex_state = 62, .external_lex_state = 5},
-  [731] = {.lex_state = 64, .external_lex_state = 4},
+  [729] = {.lex_state = 73, .external_lex_state = 4},
+  [730] = {.lex_state = 73, .external_lex_state = 5},
+  [731] = {.lex_state = 74, .external_lex_state = 4},
   [732] = {.lex_state = 3, .external_lex_state = 4},
   [733] = {.lex_state = 2, .external_lex_state = 8},
-  [734] = {.lex_state = 62, .external_lex_state = 5},
+  [734] = {.lex_state = 73, .external_lex_state = 5},
   [735] = {.lex_state = 1, .external_lex_state = 9},
   [736] = {.lex_state = 2, .external_lex_state = 8},
   [737] = {.lex_state = 3, .external_lex_state = 4},
-  [738] = {.lex_state = 64, .external_lex_state = 4},
+  [738] = {.lex_state = 74, .external_lex_state = 4},
   [739] = {.lex_state = 1, .external_lex_state = 9},
   [740] = {.lex_state = 3, .external_lex_state = 4},
   [741] = {.lex_state = 2, .external_lex_state = 8},
@@ -4795,7 +4923,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [756] = {.lex_state = 4, .external_lex_state = 4},
   [757] = {.lex_state = 2, .external_lex_state = 11},
   [758] = {.lex_state = 2, .external_lex_state = 11},
-  [759] = {.lex_state = 62, .external_lex_state = 4},
+  [759] = {.lex_state = 73, .external_lex_state = 4},
   [760] = {.lex_state = 4, .external_lex_state = 4},
   [761] = {.lex_state = 3, .external_lex_state = 4},
   [762] = {.lex_state = 4, .external_lex_state = 4},
@@ -4808,7 +4936,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [769] = {.lex_state = 0, .external_lex_state = 4},
   [770] = {.lex_state = 9, .external_lex_state = 4},
   [771] = {.lex_state = 0, .external_lex_state = 4},
-  [772] = {.lex_state = 62, .external_lex_state = 4},
+  [772] = {.lex_state = 73, .external_lex_state = 4},
   [773] = {.lex_state = 0, .external_lex_state = 4},
   [774] = {.lex_state = 9, .external_lex_state = 4},
   [775] = {.lex_state = 9, .external_lex_state = 4},
@@ -4817,19 +4945,19 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [778] = {.lex_state = 9, .external_lex_state = 4},
   [779] = {.lex_state = 9, .external_lex_state = 4},
   [780] = {.lex_state = 9, .external_lex_state = 4},
-  [781] = {.lex_state = 62, .external_lex_state = 5},
-  [782] = {.lex_state = 62, .external_lex_state = 5},
-  [783] = {.lex_state = 62, .external_lex_state = 5},
+  [781] = {.lex_state = 73, .external_lex_state = 5},
+  [782] = {.lex_state = 73, .external_lex_state = 5},
+  [783] = {.lex_state = 73, .external_lex_state = 5},
   [784] = {.lex_state = 0, .external_lex_state = 6},
   [785] = {.lex_state = 0, .external_lex_state = 4},
   [786] = {.lex_state = 0, .external_lex_state = 6},
   [787] = {.lex_state = 9, .external_lex_state = 4},
   [788] = {.lex_state = 9, .external_lex_state = 4},
   [789] = {.lex_state = 0, .external_lex_state = 6},
-  [790] = {.lex_state = 62, .external_lex_state = 5},
+  [790] = {.lex_state = 73, .external_lex_state = 5},
   [791] = {.lex_state = 0, .external_lex_state = 4},
-  [792] = {.lex_state = 62, .external_lex_state = 5},
-  [793] = {.lex_state = 62, .external_lex_state = 5},
+  [792] = {.lex_state = 73, .external_lex_state = 5},
+  [793] = {.lex_state = 73, .external_lex_state = 5},
   [794] = {.lex_state = 9, .external_lex_state = 4},
   [795] = {.lex_state = 0, .external_lex_state = 4},
   [796] = {.lex_state = 9, .external_lex_state = 4},
@@ -4850,17 +4978,17 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [811] = {.lex_state = 9, .external_lex_state = 4},
   [812] = {.lex_state = 0, .external_lex_state = 4},
   [813] = {.lex_state = 4, .external_lex_state = 4},
-  [814] = {.lex_state = 62, .external_lex_state = 4},
+  [814] = {.lex_state = 73, .external_lex_state = 4},
   [815] = {.lex_state = 0, .external_lex_state = 4},
-  [816] = {.lex_state = 62, .external_lex_state = 4},
+  [816] = {.lex_state = 73, .external_lex_state = 4},
   [817] = {.lex_state = 3, .external_lex_state = 4},
   [818] = {.lex_state = 0, .external_lex_state = 4},
   [819] = {.lex_state = 0, .external_lex_state = 4},
-  [820] = {.lex_state = 62, .external_lex_state = 5},
+  [820] = {.lex_state = 73, .external_lex_state = 5},
   [821] = {.lex_state = 0, .external_lex_state = 6},
   [822] = {.lex_state = 0, .external_lex_state = 4},
-  [823] = {.lex_state = 62, .external_lex_state = 5},
-  [824] = {.lex_state = 62, .external_lex_state = 5},
+  [823] = {.lex_state = 73, .external_lex_state = 5},
+  [824] = {.lex_state = 73, .external_lex_state = 5},
   [825] = {.lex_state = 0, .external_lex_state = 4},
   [826] = {.lex_state = 0, .external_lex_state = 4},
   [827] = {.lex_state = 0, .external_lex_state = 4},
@@ -4896,12 +5024,12 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [857] = {.lex_state = 0, .external_lex_state = 4},
   [858] = {.lex_state = 3, .external_lex_state = 4},
   [859] = {.lex_state = 0, .external_lex_state = 4},
-  [860] = {.lex_state = 64, .external_lex_state = 4},
+  [860] = {.lex_state = 74, .external_lex_state = 4},
   [861] = {.lex_state = 3, .external_lex_state = 4},
   [862] = {.lex_state = 3, .external_lex_state = 4},
   [863] = {.lex_state = 0, .external_lex_state = 4},
   [864] = {.lex_state = 0, .external_lex_state = 4},
-  [865] = {.lex_state = 64, .external_lex_state = 4},
+  [865] = {.lex_state = 74, .external_lex_state = 4},
   [866] = {.lex_state = 3, .external_lex_state = 4},
   [867] = {.lex_state = 0, .external_lex_state = 4},
   [868] = {.lex_state = 0, .external_lex_state = 4},
@@ -4933,13 +5061,13 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [894] = {.lex_state = 0, .external_lex_state = 4},
   [895] = {.lex_state = 0, .external_lex_state = 5},
   [896] = {.lex_state = 0, .external_lex_state = 4},
-  [897] = {.lex_state = 64, .external_lex_state = 4},
+  [897] = {.lex_state = 74, .external_lex_state = 4},
   [898] = {.lex_state = 4, .external_lex_state = 4},
   [899] = {.lex_state = 0, .external_lex_state = 4},
   [900] = {.lex_state = 0, .external_lex_state = 4},
   [901] = {.lex_state = 0, .external_lex_state = 4},
   [902] = {.lex_state = 0, .external_lex_state = 4},
-  [903] = {.lex_state = 64, .external_lex_state = 4},
+  [903] = {.lex_state = 74, .external_lex_state = 4},
   [904] = {.lex_state = 0, .external_lex_state = 4},
   [905] = {.lex_state = 4, .external_lex_state = 4},
   [906] = {.lex_state = 0, .external_lex_state = 4},
@@ -4950,20 +5078,20 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [911] = {.lex_state = 0, .external_lex_state = 4},
   [912] = {.lex_state = 0, .external_lex_state = 4},
   [913] = {.lex_state = 4, .external_lex_state = 4},
-  [914] = {.lex_state = 64, .external_lex_state = 4},
+  [914] = {.lex_state = 74, .external_lex_state = 4},
   [915] = {.lex_state = 4, .external_lex_state = 4},
   [916] = {.lex_state = 0, .external_lex_state = 4},
   [917] = {.lex_state = 0, .external_lex_state = 4},
   [918] = {.lex_state = 0, .external_lex_state = 4},
   [919] = {.lex_state = 0, .external_lex_state = 4},
-  [920] = {.lex_state = 62, .external_lex_state = 4},
+  [920] = {.lex_state = 73, .external_lex_state = 4},
   [921] = {.lex_state = 0, .external_lex_state = 4},
   [922] = {.lex_state = 0, .external_lex_state = 5},
-  [923] = {.lex_state = 64, .external_lex_state = 4},
+  [923] = {.lex_state = 74, .external_lex_state = 4},
   [924] = {.lex_state = 0, .external_lex_state = 4},
   [925] = {.lex_state = 4, .external_lex_state = 4},
   [926] = {.lex_state = 0, .external_lex_state = 4},
-  [927] = {.lex_state = 62, .external_lex_state = 4},
+  [927] = {.lex_state = 73, .external_lex_state = 4},
   [928] = {.lex_state = 0, .external_lex_state = 4},
   [929] = {.lex_state = 0, .external_lex_state = 4},
   [930] = {.lex_state = 3, .external_lex_state = 4},
@@ -4972,7 +5100,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [933] = {.lex_state = 0, .external_lex_state = 4},
   [934] = {.lex_state = 0, .external_lex_state = 4},
   [935] = {.lex_state = 0, .external_lex_state = 4},
-  [936] = {.lex_state = 64, .external_lex_state = 4},
+  [936] = {.lex_state = 74, .external_lex_state = 4},
   [937] = {.lex_state = 4, .external_lex_state = 4},
   [938] = {.lex_state = 3, .external_lex_state = 4},
   [939] = {.lex_state = 0, .external_lex_state = 4},
@@ -4983,8 +5111,8 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [944] = {.lex_state = 0, .external_lex_state = 4},
   [945] = {.lex_state = 0, .external_lex_state = 4},
   [946] = {.lex_state = 0, .external_lex_state = 5},
-  [947] = {.lex_state = 64, .external_lex_state = 4},
-  [948] = {.lex_state = 64, .external_lex_state = 4},
+  [947] = {.lex_state = 74, .external_lex_state = 4},
+  [948] = {.lex_state = 74, .external_lex_state = 4},
   [949] = {.lex_state = 0, .external_lex_state = 4},
   [950] = {.lex_state = 0, .external_lex_state = 4},
   [951] = {.lex_state = 0, .external_lex_state = 4},
@@ -4995,7 +5123,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [956] = {.lex_state = 4, .external_lex_state = 4},
   [957] = {.lex_state = 3, .external_lex_state = 4},
   [958] = {.lex_state = 3, .external_lex_state = 4},
-  [959] = {.lex_state = 64, .external_lex_state = 4},
+  [959] = {.lex_state = 74, .external_lex_state = 4},
   [960] = {.lex_state = 0, .external_lex_state = 4},
   [961] = {.lex_state = 3, .external_lex_state = 4},
   [962] = {.lex_state = 0, .external_lex_state = 4},
@@ -5035,7 +5163,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [996] = {.lex_state = 3, .external_lex_state = 4},
   [997] = {.lex_state = 0, .external_lex_state = 4},
   [998] = {.lex_state = 0, .external_lex_state = 4},
-  [999] = {.lex_state = 64, .external_lex_state = 4},
+  [999] = {.lex_state = 74, .external_lex_state = 4},
   [1000] = {.lex_state = 4, .external_lex_state = 4},
   [1001] = {.lex_state = 3, .external_lex_state = 4},
   [1002] = {.lex_state = 0, .external_lex_state = 4},
@@ -5055,24 +5183,24 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [1016] = {.lex_state = 4, .external_lex_state = 4},
   [1017] = {.lex_state = 3, .external_lex_state = 4},
   [1018] = {.lex_state = 0, .external_lex_state = 4},
-  [1019] = {.lex_state = 64, .external_lex_state = 4},
+  [1019] = {.lex_state = 74, .external_lex_state = 4},
   [1020] = {.lex_state = 0, .external_lex_state = 4},
   [1021] = {.lex_state = 0, .external_lex_state = 4},
   [1022] = {.lex_state = 3, .external_lex_state = 4},
   [1023] = {.lex_state = 0, .external_lex_state = 4},
   [1024] = {.lex_state = 3, .external_lex_state = 4},
   [1025] = {.lex_state = 0, .external_lex_state = 4},
-  [1026] = {.lex_state = 64, .external_lex_state = 4},
+  [1026] = {.lex_state = 74, .external_lex_state = 4},
   [1027] = {.lex_state = 0, .external_lex_state = 4},
-  [1028] = {.lex_state = 64, .external_lex_state = 4},
+  [1028] = {.lex_state = 74, .external_lex_state = 4},
   [1029] = {.lex_state = 0, .external_lex_state = 4},
-  [1030] = {.lex_state = 64, .external_lex_state = 4},
+  [1030] = {.lex_state = 74, .external_lex_state = 4},
   [1031] = {.lex_state = 0, .external_lex_state = 4},
-  [1032] = {.lex_state = 64, .external_lex_state = 4},
+  [1032] = {.lex_state = 74, .external_lex_state = 4},
   [1033] = {.lex_state = 0, .external_lex_state = 4},
-  [1034] = {.lex_state = 64, .external_lex_state = 4},
+  [1034] = {.lex_state = 74, .external_lex_state = 4},
   [1035] = {.lex_state = 0, .external_lex_state = 4},
-  [1036] = {.lex_state = 64, .external_lex_state = 4},
+  [1036] = {.lex_state = 74, .external_lex_state = 4},
   [1037] = {.lex_state = 0, .external_lex_state = 4},
   [1038] = {.lex_state = 0, .external_lex_state = 5},
   [1039] = {.lex_state = 0, .external_lex_state = 5},
@@ -5174,6 +5302,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_priority] = ACTIONS(1),
     [anon_sym_doc] = ACTIONS(1),
     [anon_sym_rec] = ACTIONS(1),
+    [anon_sym_not_exported] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
     [anon_sym_let] = ACTIONS(1),
     [anon_sym_EQ] = ACTIONS(1),
@@ -5247,7 +5376,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_ite_expr] = STATE(574),
     [sym_annotated_infix_expr] = STATE(574),
     [sym_forall] = STATE(574),
-    [sym_applicative] = STATE(72),
+    [sym_applicative] = STATE(78),
     [sym_type_array] = STATE(413),
     [sym_record_operand] = STATE(235),
     [sym_record_operation_chain] = STATE(240),
@@ -7615,7 +7744,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(30), 1,
       sym_let_in_block,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -7707,7 +7836,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(30), 1,
       sym_let_in_block,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -7799,7 +7928,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(65), 1,
       sym_let_in_block,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -7891,7 +8020,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(30), 1,
       sym_let_in_block,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -8075,7 +8204,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(65), 1,
       sym_let_in_block,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -8167,7 +8296,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(30), 1,
       sym_let_in_block,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -8259,7 +8388,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(39), 1,
       sym_let_in_block,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -8351,7 +8480,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(35), 1,
       sym_let_in_block,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -8443,7 +8572,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(56), 1,
       sym_let_in_block,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -8627,7 +8756,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(39), 1,
       sym_let_in_block,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -8719,7 +8848,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(39), 1,
       sym_let_in_block,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -8811,7 +8940,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(56), 1,
       sym_let_in_block,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -8995,7 +9124,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(56), 1,
       sym_let_in_block,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -9087,7 +9216,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(65), 1,
       sym_let_in_block,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -9271,7 +9400,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(56), 1,
       sym_let_in_block,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -9363,7 +9492,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(30), 1,
       sym_let_in_block,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -9455,7 +9584,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(39), 1,
       sym_let_in_block,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -9547,7 +9676,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(65), 1,
       sym_let_in_block,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -9639,7 +9768,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(65), 1,
       sym_let_in_block,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -9731,7 +9860,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(65), 1,
       sym_let_in_block,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -9823,7 +9952,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(65), 1,
       sym_let_in_block,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -10007,7 +10136,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(65), 1,
       sym_let_in_block,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -10099,7 +10228,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(35), 1,
       sym_let_in_block,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -10283,7 +10412,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(56), 1,
       sym_let_in_block,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -10375,7 +10504,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(39), 1,
       sym_let_in_block,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -10559,7 +10688,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(56), 1,
       sym_let_in_block,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -10835,7 +10964,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(30), 1,
       sym_let_in_block,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -10927,7 +11056,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(56), 1,
       sym_let_in_block,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -11019,7 +11148,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(56), 1,
       sym_let_in_block,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -11111,7 +11240,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(65), 1,
       sym_let_in_block,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -11203,7 +11332,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(56), 1,
       sym_let_in_block,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -11295,7 +11424,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(35), 1,
       sym_let_in_block,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -11387,7 +11516,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag_start,
     STATE(30), 1,
       sym_let_in_block,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -11436,7 +11565,96 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [7913] = 21,
+  [7913] = 36,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(39), 1,
+      anon_sym_BANG,
+    ACTIONS(287), 1,
+      sym_num_literal,
+    ACTIONS(291), 1,
+      sym_raw_enum_tag,
+    ACTIONS(295), 1,
+      anon_sym_match,
+    ACTIONS(297), 1,
+      anon_sym_LBRACE,
+    ACTIONS(301), 1,
+      anon_sym_forall,
+    ACTIONS(303), 1,
+      anon_sym_import,
+    ACTIONS(305), 1,
+      anon_sym_Array,
+    ACTIONS(309), 1,
+      anon_sym_LPAREN,
+    ACTIONS(311), 1,
+      anon_sym_LBRACK,
+    ACTIONS(315), 1,
+      anon_sym_PERCENT,
+    ACTIONS(317), 1,
+      anon_sym_DASH,
+    ACTIONS(319), 1,
+      anon_sym_LBRACK_PIPE,
+    ACTIONS(321), 1,
+      sym_multstr_start,
+    ACTIONS(323), 1,
+      sym__str_start,
+    ACTIONS(325), 1,
+      sym_quoted_enum_tag_start,
+    ACTIONS(329), 1,
+      anon_sym_priority,
+    ACTIONS(331), 1,
+      anon_sym_doc,
+    ACTIONS(333), 1,
+      anon_sym_rec,
+    STATE(73), 1,
+      sym_applicative,
+    STATE(205), 1,
+      sym_infix_u_op_5,
+    STATE(273), 1,
+      sym_quoted_enum_tag,
+    STATE(283), 1,
+      sym_record_operand,
+    STATE(288), 1,
+      sym_type_builtin,
+    STATE(488), 1,
+      sym_infix_expr,
+    STATE(565), 1,
+      sym_forall,
+    STATE(566), 1,
+      sym_types,
+    ACTIONS(289), 2,
+      sym_ident,
+      anon_sym_null,
+    ACTIONS(313), 2,
+      anon_sym_true,
+      anon_sym_false,
+    STATE(284), 2,
+      sym_record_operation_chain,
+      sym_atom,
+    STATE(389), 2,
+      sym_str_chunks_single,
+      sym_str_chunks_multi,
+    STATE(430), 2,
+      sym_match_expr,
+      sym_type_array,
+    ACTIONS(307), 4,
+      anon_sym_Dyn,
+      anon_sym_Num,
+      anon_sym_Bool,
+      anon_sym_Str,
+    ACTIONS(327), 4,
+      anon_sym_default,
+      anon_sym_force,
+      anon_sym_optional,
+      anon_sym_not_exported,
+    STATE(272), 6,
+      sym_uni_record,
+      sym_bool,
+      sym_str_chunks,
+      sym_enum_tag,
+      sym_builtin,
+      sym_type_atom,
+  [8038] = 21,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(207), 1,
@@ -11510,7 +11728,185 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [8008] = 21,
+  [8133] = 36,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(39), 1,
+      anon_sym_BANG,
+    ACTIONS(49), 1,
+      sym_num_literal,
+    ACTIONS(53), 1,
+      sym_raw_enum_tag,
+    ACTIONS(57), 1,
+      anon_sym_match,
+    ACTIONS(59), 1,
+      anon_sym_LBRACE,
+    ACTIONS(63), 1,
+      anon_sym_forall,
+    ACTIONS(65), 1,
+      anon_sym_import,
+    ACTIONS(67), 1,
+      anon_sym_Array,
+    ACTIONS(71), 1,
+      anon_sym_LPAREN,
+    ACTIONS(73), 1,
+      anon_sym_LBRACK,
+    ACTIONS(103), 1,
+      anon_sym_LBRACK_PIPE,
+    ACTIONS(105), 1,
+      sym_multstr_start,
+    ACTIONS(107), 1,
+      sym__str_start,
+    ACTIONS(109), 1,
+      sym_quoted_enum_tag_start,
+    ACTIONS(119), 1,
+      anon_sym_PERCENT,
+    ACTIONS(121), 1,
+      anon_sym_DASH,
+    ACTIONS(329), 1,
+      anon_sym_priority,
+    ACTIONS(331), 1,
+      anon_sym_doc,
+    ACTIONS(333), 1,
+      anon_sym_rec,
+    STATE(8), 1,
+      sym_applicative,
+    STATE(84), 1,
+      sym_record_operand,
+    STATE(88), 1,
+      sym_quoted_enum_tag,
+    STATE(92), 1,
+      sym_type_builtin,
+    STATE(175), 1,
+      sym_infix_u_op_5,
+    STATE(454), 1,
+      sym_infix_expr,
+    STATE(565), 1,
+      sym_forall,
+    STATE(566), 1,
+      sym_types,
+    ACTIONS(51), 2,
+      sym_ident,
+      anon_sym_null,
+    ACTIONS(77), 2,
+      anon_sym_true,
+      anon_sym_false,
+    STATE(91), 2,
+      sym_record_operation_chain,
+      sym_atom,
+    STATE(115), 2,
+      sym_str_chunks_single,
+      sym_str_chunks_multi,
+    STATE(131), 2,
+      sym_match_expr,
+      sym_type_array,
+    ACTIONS(69), 4,
+      anon_sym_Dyn,
+      anon_sym_Num,
+      anon_sym_Bool,
+      anon_sym_Str,
+    ACTIONS(327), 4,
+      anon_sym_default,
+      anon_sym_force,
+      anon_sym_optional,
+      anon_sym_not_exported,
+    STATE(80), 6,
+      sym_uni_record,
+      sym_bool,
+      sym_str_chunks,
+      sym_enum_tag,
+      sym_builtin,
+      sym_type_atom,
+  [8258] = 36,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(5), 1,
+      sym_num_literal,
+    ACTIONS(9), 1,
+      sym_raw_enum_tag,
+    ACTIONS(15), 1,
+      anon_sym_match,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE,
+    ACTIONS(21), 1,
+      anon_sym_forall,
+    ACTIONS(23), 1,
+      anon_sym_import,
+    ACTIONS(25), 1,
+      anon_sym_Array,
+    ACTIONS(29), 1,
+      anon_sym_LPAREN,
+    ACTIONS(31), 1,
+      anon_sym_LBRACK,
+    ACTIONS(35), 1,
+      anon_sym_PERCENT,
+    ACTIONS(37), 1,
+      anon_sym_DASH,
+    ACTIONS(39), 1,
+      anon_sym_BANG,
+    ACTIONS(41), 1,
+      anon_sym_LBRACK_PIPE,
+    ACTIONS(43), 1,
+      sym_multstr_start,
+    ACTIONS(45), 1,
+      sym__str_start,
+    ACTIONS(47), 1,
+      sym_quoted_enum_tag_start,
+    ACTIONS(329), 1,
+      anon_sym_priority,
+    ACTIONS(331), 1,
+      anon_sym_doc,
+    ACTIONS(333), 1,
+      anon_sym_rec,
+    STATE(78), 1,
+      sym_applicative,
+    STATE(212), 1,
+      sym_infix_u_op_5,
+    STATE(218), 1,
+      sym_quoted_enum_tag,
+    STATE(235), 1,
+      sym_record_operand,
+    STATE(253), 1,
+      sym_type_builtin,
+    STATE(510), 1,
+      sym_infix_expr,
+    STATE(565), 1,
+      sym_forall,
+    STATE(566), 1,
+      sym_types,
+    ACTIONS(7), 2,
+      sym_ident,
+      anon_sym_null,
+    ACTIONS(33), 2,
+      anon_sym_true,
+      anon_sym_false,
+    STATE(240), 2,
+      sym_record_operation_chain,
+      sym_atom,
+    STATE(341), 2,
+      sym_str_chunks_single,
+      sym_str_chunks_multi,
+    STATE(413), 2,
+      sym_match_expr,
+      sym_type_array,
+    ACTIONS(27), 4,
+      anon_sym_Dyn,
+      anon_sym_Num,
+      anon_sym_Bool,
+      anon_sym_Str,
+    ACTIONS(327), 4,
+      anon_sym_default,
+      anon_sym_force,
+      anon_sym_optional,
+      anon_sym_not_exported,
+    STATE(217), 6,
+      sym_uni_record,
+      sym_bool,
+      sym_str_chunks,
+      sym_enum_tag,
+      sym_builtin,
+      sym_type_atom,
+  [8383] = 21,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(287), 1,
@@ -11584,7 +11980,274 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [8103] = 21,
+  [8478] = 36,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(39), 1,
+      anon_sym_BANG,
+    ACTIONS(167), 1,
+      sym_num_literal,
+    ACTIONS(171), 1,
+      sym_raw_enum_tag,
+    ACTIONS(175), 1,
+      anon_sym_match,
+    ACTIONS(177), 1,
+      anon_sym_LBRACE,
+    ACTIONS(181), 1,
+      anon_sym_forall,
+    ACTIONS(183), 1,
+      anon_sym_import,
+    ACTIONS(185), 1,
+      anon_sym_Array,
+    ACTIONS(189), 1,
+      anon_sym_LPAREN,
+    ACTIONS(191), 1,
+      anon_sym_LBRACK,
+    ACTIONS(195), 1,
+      anon_sym_PERCENT,
+    ACTIONS(197), 1,
+      anon_sym_DASH,
+    ACTIONS(199), 1,
+      anon_sym_LBRACK_PIPE,
+    ACTIONS(201), 1,
+      sym_multstr_start,
+    ACTIONS(203), 1,
+      sym__str_start,
+    ACTIONS(205), 1,
+      sym_quoted_enum_tag_start,
+    ACTIONS(329), 1,
+      anon_sym_priority,
+    ACTIONS(331), 1,
+      anon_sym_doc,
+    ACTIONS(333), 1,
+      anon_sym_rec,
+    STATE(79), 1,
+      sym_applicative,
+    STATE(179), 1,
+      sym_infix_u_op_5,
+    STATE(277), 1,
+      sym_quoted_enum_tag,
+    STATE(346), 1,
+      sym_type_builtin,
+    STATE(349), 1,
+      sym_record_operand,
+    STATE(501), 1,
+      sym_infix_expr,
+    STATE(565), 1,
+      sym_forall,
+    STATE(566), 1,
+      sym_types,
+    ACTIONS(169), 2,
+      sym_ident,
+      anon_sym_null,
+    ACTIONS(193), 2,
+      anon_sym_true,
+      anon_sym_false,
+    STATE(260), 2,
+      sym_str_chunks_single,
+      sym_str_chunks_multi,
+    STATE(348), 2,
+      sym_record_operation_chain,
+      sym_atom,
+    STATE(435), 2,
+      sym_match_expr,
+      sym_type_array,
+    ACTIONS(187), 4,
+      anon_sym_Dyn,
+      anon_sym_Num,
+      anon_sym_Bool,
+      anon_sym_Str,
+    ACTIONS(327), 4,
+      anon_sym_default,
+      anon_sym_force,
+      anon_sym_optional,
+      anon_sym_not_exported,
+    STATE(384), 6,
+      sym_uni_record,
+      sym_bool,
+      sym_str_chunks,
+      sym_enum_tag,
+      sym_builtin,
+      sym_type_atom,
+  [8603] = 36,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(39), 1,
+      anon_sym_BANG,
+    ACTIONS(247), 1,
+      sym_num_literal,
+    ACTIONS(251), 1,
+      sym_raw_enum_tag,
+    ACTIONS(255), 1,
+      anon_sym_match,
+    ACTIONS(257), 1,
+      anon_sym_LBRACE,
+    ACTIONS(261), 1,
+      anon_sym_forall,
+    ACTIONS(263), 1,
+      anon_sym_import,
+    ACTIONS(265), 1,
+      anon_sym_Array,
+    ACTIONS(269), 1,
+      anon_sym_LPAREN,
+    ACTIONS(271), 1,
+      anon_sym_LBRACK,
+    ACTIONS(275), 1,
+      anon_sym_PERCENT,
+    ACTIONS(277), 1,
+      anon_sym_DASH,
+    ACTIONS(279), 1,
+      anon_sym_LBRACK_PIPE,
+    ACTIONS(281), 1,
+      sym_multstr_start,
+    ACTIONS(283), 1,
+      sym__str_start,
+    ACTIONS(285), 1,
+      sym_quoted_enum_tag_start,
+    ACTIONS(337), 1,
+      anon_sym_priority,
+    ACTIONS(339), 1,
+      anon_sym_doc,
+    ACTIONS(341), 1,
+      anon_sym_rec,
+    STATE(77), 1,
+      sym_applicative,
+    STATE(150), 1,
+      sym_infix_u_op_5,
+    STATE(213), 1,
+      sym_quoted_enum_tag,
+    STATE(248), 1,
+      sym_type_builtin,
+    STATE(271), 1,
+      sym_record_operand,
+    STATE(499), 1,
+      sym_infix_expr,
+    STATE(790), 1,
+      sym_forall,
+    STATE(792), 1,
+      sym_types,
+    ACTIONS(249), 2,
+      sym_ident,
+      anon_sym_null,
+    ACTIONS(273), 2,
+      anon_sym_true,
+      anon_sym_false,
+    STATE(265), 2,
+      sym_record_operation_chain,
+      sym_atom,
+    STATE(347), 2,
+      sym_str_chunks_single,
+      sym_str_chunks_multi,
+    STATE(429), 2,
+      sym_match_expr,
+      sym_type_array,
+    ACTIONS(267), 4,
+      anon_sym_Dyn,
+      anon_sym_Num,
+      anon_sym_Bool,
+      anon_sym_Str,
+    ACTIONS(335), 4,
+      anon_sym_default,
+      anon_sym_force,
+      anon_sym_optional,
+      anon_sym_not_exported,
+    STATE(298), 6,
+      sym_uni_record,
+      sym_bool,
+      sym_str_chunks,
+      sym_enum_tag,
+      sym_builtin,
+      sym_type_atom,
+  [8728] = 36,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(39), 1,
+      anon_sym_BANG,
+    ACTIONS(207), 1,
+      sym_num_literal,
+    ACTIONS(211), 1,
+      sym_raw_enum_tag,
+    ACTIONS(215), 1,
+      anon_sym_match,
+    ACTIONS(217), 1,
+      anon_sym_LBRACE,
+    ACTIONS(221), 1,
+      anon_sym_forall,
+    ACTIONS(223), 1,
+      anon_sym_import,
+    ACTIONS(225), 1,
+      anon_sym_Array,
+    ACTIONS(229), 1,
+      anon_sym_LPAREN,
+    ACTIONS(231), 1,
+      anon_sym_LBRACK,
+    ACTIONS(235), 1,
+      anon_sym_PERCENT,
+    ACTIONS(237), 1,
+      anon_sym_DASH,
+    ACTIONS(239), 1,
+      anon_sym_LBRACK_PIPE,
+    ACTIONS(241), 1,
+      sym_multstr_start,
+    ACTIONS(243), 1,
+      sym__str_start,
+    ACTIONS(245), 1,
+      sym_quoted_enum_tag_start,
+    ACTIONS(329), 1,
+      anon_sym_priority,
+    ACTIONS(331), 1,
+      anon_sym_doc,
+    ACTIONS(333), 1,
+      anon_sym_rec,
+    STATE(70), 1,
+      sym_applicative,
+    STATE(197), 1,
+      sym_infix_u_op_5,
+    STATE(259), 1,
+      sym_type_builtin,
+    STATE(262), 1,
+      sym_record_operand,
+    STATE(274), 1,
+      sym_quoted_enum_tag,
+    STATE(522), 1,
+      sym_infix_expr,
+    STATE(565), 1,
+      sym_forall,
+    STATE(566), 1,
+      sym_types,
+    ACTIONS(209), 2,
+      sym_ident,
+      anon_sym_null,
+    ACTIONS(233), 2,
+      anon_sym_true,
+      anon_sym_false,
+    STATE(261), 2,
+      sym_record_operation_chain,
+      sym_atom,
+    STATE(285), 2,
+      sym_str_chunks_single,
+      sym_str_chunks_multi,
+    STATE(422), 2,
+      sym_match_expr,
+      sym_type_array,
+    ACTIONS(227), 4,
+      anon_sym_Dyn,
+      anon_sym_Num,
+      anon_sym_Bool,
+      anon_sym_Str,
+    ACTIONS(327), 4,
+      anon_sym_default,
+      anon_sym_force,
+      anon_sym_optional,
+      anon_sym_not_exported,
+    STATE(279), 6,
+      sym_uni_record,
+      sym_bool,
+      sym_str_chunks,
+      sym_enum_tag,
+      sym_builtin,
+      sym_type_atom,
+  [8853] = 21,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(247), 1,
@@ -11658,7 +12321,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [8198] = 21,
+  [8948] = 21,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -11732,7 +12395,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [8293] = 21,
+  [9043] = 21,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(167), 1,
@@ -11806,535 +12469,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [8388] = 36,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(39), 1,
-      anon_sym_BANG,
-    ACTIONS(287), 1,
-      sym_num_literal,
-    ACTIONS(291), 1,
-      sym_raw_enum_tag,
-    ACTIONS(295), 1,
-      anon_sym_match,
-    ACTIONS(297), 1,
-      anon_sym_LBRACE,
-    ACTIONS(301), 1,
-      anon_sym_forall,
-    ACTIONS(303), 1,
-      anon_sym_import,
-    ACTIONS(305), 1,
-      anon_sym_Array,
-    ACTIONS(309), 1,
-      anon_sym_LPAREN,
-    ACTIONS(311), 1,
-      anon_sym_LBRACK,
-    ACTIONS(315), 1,
-      anon_sym_PERCENT,
-    ACTIONS(317), 1,
-      anon_sym_DASH,
-    ACTIONS(319), 1,
-      anon_sym_LBRACK_PIPE,
-    ACTIONS(321), 1,
-      sym_multstr_start,
-    ACTIONS(323), 1,
-      sym__str_start,
-    ACTIONS(325), 1,
-      sym_quoted_enum_tag_start,
-    ACTIONS(329), 1,
-      anon_sym_priority,
-    ACTIONS(331), 1,
-      anon_sym_doc,
-    ACTIONS(333), 1,
-      anon_sym_rec,
-    STATE(70), 1,
-      sym_applicative,
-    STATE(205), 1,
-      sym_infix_u_op_5,
-    STATE(273), 1,
-      sym_quoted_enum_tag,
-    STATE(283), 1,
-      sym_record_operand,
-    STATE(288), 1,
-      sym_type_builtin,
-    STATE(488), 1,
-      sym_infix_expr,
-    STATE(565), 1,
-      sym_forall,
-    STATE(566), 1,
-      sym_types,
-    ACTIONS(289), 2,
-      sym_ident,
-      anon_sym_null,
-    ACTIONS(313), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(284), 2,
-      sym_record_operation_chain,
-      sym_atom,
-    STATE(389), 2,
-      sym_str_chunks_single,
-      sym_str_chunks_multi,
-    STATE(430), 2,
-      sym_match_expr,
-      sym_type_array,
-    ACTIONS(327), 3,
-      anon_sym_default,
-      anon_sym_force,
-      anon_sym_optional,
-    ACTIONS(307), 4,
-      anon_sym_Dyn,
-      anon_sym_Num,
-      anon_sym_Bool,
-      anon_sym_Str,
-    STATE(272), 6,
-      sym_uni_record,
-      sym_bool,
-      sym_str_chunks,
-      sym_enum_tag,
-      sym_builtin,
-      sym_type_atom,
-  [8512] = 36,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(39), 1,
-      anon_sym_BANG,
-    ACTIONS(49), 1,
-      sym_num_literal,
-    ACTIONS(53), 1,
-      sym_raw_enum_tag,
-    ACTIONS(57), 1,
-      anon_sym_match,
-    ACTIONS(59), 1,
-      anon_sym_LBRACE,
-    ACTIONS(63), 1,
-      anon_sym_forall,
-    ACTIONS(65), 1,
-      anon_sym_import,
-    ACTIONS(67), 1,
-      anon_sym_Array,
-    ACTIONS(71), 1,
-      anon_sym_LPAREN,
-    ACTIONS(73), 1,
-      anon_sym_LBRACK,
-    ACTIONS(103), 1,
-      anon_sym_LBRACK_PIPE,
-    ACTIONS(105), 1,
-      sym_multstr_start,
-    ACTIONS(107), 1,
-      sym__str_start,
-    ACTIONS(109), 1,
-      sym_quoted_enum_tag_start,
-    ACTIONS(119), 1,
-      anon_sym_PERCENT,
-    ACTIONS(121), 1,
-      anon_sym_DASH,
-    ACTIONS(329), 1,
-      anon_sym_priority,
-    ACTIONS(331), 1,
-      anon_sym_doc,
-    ACTIONS(333), 1,
-      anon_sym_rec,
-    STATE(8), 1,
-      sym_applicative,
-    STATE(84), 1,
-      sym_record_operand,
-    STATE(88), 1,
-      sym_quoted_enum_tag,
-    STATE(92), 1,
-      sym_type_builtin,
-    STATE(175), 1,
-      sym_infix_u_op_5,
-    STATE(454), 1,
-      sym_infix_expr,
-    STATE(565), 1,
-      sym_forall,
-    STATE(566), 1,
-      sym_types,
-    ACTIONS(51), 2,
-      sym_ident,
-      anon_sym_null,
-    ACTIONS(77), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(91), 2,
-      sym_record_operation_chain,
-      sym_atom,
-    STATE(115), 2,
-      sym_str_chunks_single,
-      sym_str_chunks_multi,
-    STATE(131), 2,
-      sym_match_expr,
-      sym_type_array,
-    ACTIONS(327), 3,
-      anon_sym_default,
-      anon_sym_force,
-      anon_sym_optional,
-    ACTIONS(69), 4,
-      anon_sym_Dyn,
-      anon_sym_Num,
-      anon_sym_Bool,
-      anon_sym_Str,
-    STATE(80), 6,
-      sym_uni_record,
-      sym_bool,
-      sym_str_chunks,
-      sym_enum_tag,
-      sym_builtin,
-      sym_type_atom,
-  [8636] = 36,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(5), 1,
-      sym_num_literal,
-    ACTIONS(9), 1,
-      sym_raw_enum_tag,
-    ACTIONS(15), 1,
-      anon_sym_match,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE,
-    ACTIONS(21), 1,
-      anon_sym_forall,
-    ACTIONS(23), 1,
-      anon_sym_import,
-    ACTIONS(25), 1,
-      anon_sym_Array,
-    ACTIONS(29), 1,
-      anon_sym_LPAREN,
-    ACTIONS(31), 1,
-      anon_sym_LBRACK,
-    ACTIONS(35), 1,
-      anon_sym_PERCENT,
-    ACTIONS(37), 1,
-      anon_sym_DASH,
-    ACTIONS(39), 1,
-      anon_sym_BANG,
-    ACTIONS(41), 1,
-      anon_sym_LBRACK_PIPE,
-    ACTIONS(43), 1,
-      sym_multstr_start,
-    ACTIONS(45), 1,
-      sym__str_start,
-    ACTIONS(47), 1,
-      sym_quoted_enum_tag_start,
-    ACTIONS(329), 1,
-      anon_sym_priority,
-    ACTIONS(331), 1,
-      anon_sym_doc,
-    ACTIONS(333), 1,
-      anon_sym_rec,
-    STATE(72), 1,
-      sym_applicative,
-    STATE(212), 1,
-      sym_infix_u_op_5,
-    STATE(218), 1,
-      sym_quoted_enum_tag,
-    STATE(235), 1,
-      sym_record_operand,
-    STATE(253), 1,
-      sym_type_builtin,
-    STATE(510), 1,
-      sym_infix_expr,
-    STATE(565), 1,
-      sym_forall,
-    STATE(566), 1,
-      sym_types,
-    ACTIONS(7), 2,
-      sym_ident,
-      anon_sym_null,
-    ACTIONS(33), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(240), 2,
-      sym_record_operation_chain,
-      sym_atom,
-    STATE(341), 2,
-      sym_str_chunks_single,
-      sym_str_chunks_multi,
-    STATE(413), 2,
-      sym_match_expr,
-      sym_type_array,
-    ACTIONS(327), 3,
-      anon_sym_default,
-      anon_sym_force,
-      anon_sym_optional,
-    ACTIONS(27), 4,
-      anon_sym_Dyn,
-      anon_sym_Num,
-      anon_sym_Bool,
-      anon_sym_Str,
-    STATE(217), 6,
-      sym_uni_record,
-      sym_bool,
-      sym_str_chunks,
-      sym_enum_tag,
-      sym_builtin,
-      sym_type_atom,
-  [8760] = 36,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(39), 1,
-      anon_sym_BANG,
-    ACTIONS(167), 1,
-      sym_num_literal,
-    ACTIONS(171), 1,
-      sym_raw_enum_tag,
-    ACTIONS(175), 1,
-      anon_sym_match,
-    ACTIONS(177), 1,
-      anon_sym_LBRACE,
-    ACTIONS(181), 1,
-      anon_sym_forall,
-    ACTIONS(183), 1,
-      anon_sym_import,
-    ACTIONS(185), 1,
-      anon_sym_Array,
-    ACTIONS(189), 1,
-      anon_sym_LPAREN,
-    ACTIONS(191), 1,
-      anon_sym_LBRACK,
-    ACTIONS(195), 1,
-      anon_sym_PERCENT,
-    ACTIONS(197), 1,
-      anon_sym_DASH,
-    ACTIONS(199), 1,
-      anon_sym_LBRACK_PIPE,
-    ACTIONS(201), 1,
-      sym_multstr_start,
-    ACTIONS(203), 1,
-      sym__str_start,
-    ACTIONS(205), 1,
-      sym_quoted_enum_tag_start,
-    ACTIONS(329), 1,
-      anon_sym_priority,
-    ACTIONS(331), 1,
-      anon_sym_doc,
-    ACTIONS(333), 1,
-      anon_sym_rec,
-    STATE(73), 1,
-      sym_applicative,
-    STATE(179), 1,
-      sym_infix_u_op_5,
-    STATE(277), 1,
-      sym_quoted_enum_tag,
-    STATE(346), 1,
-      sym_type_builtin,
-    STATE(349), 1,
-      sym_record_operand,
-    STATE(501), 1,
-      sym_infix_expr,
-    STATE(565), 1,
-      sym_forall,
-    STATE(566), 1,
-      sym_types,
-    ACTIONS(169), 2,
-      sym_ident,
-      anon_sym_null,
-    ACTIONS(193), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(260), 2,
-      sym_str_chunks_single,
-      sym_str_chunks_multi,
-    STATE(348), 2,
-      sym_record_operation_chain,
-      sym_atom,
-    STATE(435), 2,
-      sym_match_expr,
-      sym_type_array,
-    ACTIONS(327), 3,
-      anon_sym_default,
-      anon_sym_force,
-      anon_sym_optional,
-    ACTIONS(187), 4,
-      anon_sym_Dyn,
-      anon_sym_Num,
-      anon_sym_Bool,
-      anon_sym_Str,
-    STATE(384), 6,
-      sym_uni_record,
-      sym_bool,
-      sym_str_chunks,
-      sym_enum_tag,
-      sym_builtin,
-      sym_type_atom,
-  [8884] = 36,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(39), 1,
-      anon_sym_BANG,
-    ACTIONS(247), 1,
-      sym_num_literal,
-    ACTIONS(251), 1,
-      sym_raw_enum_tag,
-    ACTIONS(255), 1,
-      anon_sym_match,
-    ACTIONS(257), 1,
-      anon_sym_LBRACE,
-    ACTIONS(261), 1,
-      anon_sym_forall,
-    ACTIONS(263), 1,
-      anon_sym_import,
-    ACTIONS(265), 1,
-      anon_sym_Array,
-    ACTIONS(269), 1,
-      anon_sym_LPAREN,
-    ACTIONS(271), 1,
-      anon_sym_LBRACK,
-    ACTIONS(275), 1,
-      anon_sym_PERCENT,
-    ACTIONS(277), 1,
-      anon_sym_DASH,
-    ACTIONS(279), 1,
-      anon_sym_LBRACK_PIPE,
-    ACTIONS(281), 1,
-      sym_multstr_start,
-    ACTIONS(283), 1,
-      sym__str_start,
-    ACTIONS(285), 1,
-      sym_quoted_enum_tag_start,
-    ACTIONS(337), 1,
-      anon_sym_priority,
-    ACTIONS(339), 1,
-      anon_sym_doc,
-    ACTIONS(341), 1,
-      anon_sym_rec,
-    STATE(71), 1,
-      sym_applicative,
-    STATE(150), 1,
-      sym_infix_u_op_5,
-    STATE(213), 1,
-      sym_quoted_enum_tag,
-    STATE(248), 1,
-      sym_type_builtin,
-    STATE(271), 1,
-      sym_record_operand,
-    STATE(499), 1,
-      sym_infix_expr,
-    STATE(790), 1,
-      sym_forall,
-    STATE(792), 1,
-      sym_types,
-    ACTIONS(249), 2,
-      sym_ident,
-      anon_sym_null,
-    ACTIONS(273), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(265), 2,
-      sym_record_operation_chain,
-      sym_atom,
-    STATE(347), 2,
-      sym_str_chunks_single,
-      sym_str_chunks_multi,
-    STATE(429), 2,
-      sym_match_expr,
-      sym_type_array,
-    ACTIONS(335), 3,
-      anon_sym_default,
-      anon_sym_force,
-      anon_sym_optional,
-    ACTIONS(267), 4,
-      anon_sym_Dyn,
-      anon_sym_Num,
-      anon_sym_Bool,
-      anon_sym_Str,
-    STATE(298), 6,
-      sym_uni_record,
-      sym_bool,
-      sym_str_chunks,
-      sym_enum_tag,
-      sym_builtin,
-      sym_type_atom,
-  [9008] = 36,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(39), 1,
-      anon_sym_BANG,
-    ACTIONS(207), 1,
-      sym_num_literal,
-    ACTIONS(211), 1,
-      sym_raw_enum_tag,
-    ACTIONS(215), 1,
-      anon_sym_match,
-    ACTIONS(217), 1,
-      anon_sym_LBRACE,
-    ACTIONS(221), 1,
-      anon_sym_forall,
-    ACTIONS(223), 1,
-      anon_sym_import,
-    ACTIONS(225), 1,
-      anon_sym_Array,
-    ACTIONS(229), 1,
-      anon_sym_LPAREN,
-    ACTIONS(231), 1,
-      anon_sym_LBRACK,
-    ACTIONS(235), 1,
-      anon_sym_PERCENT,
-    ACTIONS(237), 1,
-      anon_sym_DASH,
-    ACTIONS(239), 1,
-      anon_sym_LBRACK_PIPE,
-    ACTIONS(241), 1,
-      sym_multstr_start,
-    ACTIONS(243), 1,
-      sym__str_start,
-    ACTIONS(245), 1,
-      sym_quoted_enum_tag_start,
-    ACTIONS(329), 1,
-      anon_sym_priority,
-    ACTIONS(331), 1,
-      anon_sym_doc,
-    ACTIONS(333), 1,
-      anon_sym_rec,
-    STATE(69), 1,
-      sym_applicative,
-    STATE(197), 1,
-      sym_infix_u_op_5,
-    STATE(259), 1,
-      sym_type_builtin,
-    STATE(262), 1,
-      sym_record_operand,
-    STATE(274), 1,
-      sym_quoted_enum_tag,
-    STATE(522), 1,
-      sym_infix_expr,
-    STATE(565), 1,
-      sym_forall,
-    STATE(566), 1,
-      sym_types,
-    ACTIONS(209), 2,
-      sym_ident,
-      anon_sym_null,
-    ACTIONS(233), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(261), 2,
-      sym_record_operation_chain,
-      sym_atom,
-    STATE(285), 2,
-      sym_str_chunks_single,
-      sym_str_chunks_multi,
-    STATE(422), 2,
-      sym_match_expr,
-      sym_type_array,
-    ACTIONS(327), 3,
-      anon_sym_default,
-      anon_sym_force,
-      anon_sym_optional,
-    ACTIONS(227), 4,
-      anon_sym_Dyn,
-      anon_sym_Num,
-      anon_sym_Bool,
-      anon_sym_Str,
-    STATE(279), 6,
-      sym_uni_record,
-      sym_bool,
-      sym_str_chunks,
-      sym_enum_tag,
-      sym_builtin,
-      sym_type_atom,
-  [9132] = 3,
+  [9138] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(345), 17,
@@ -12384,7 +12519,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9185] = 3,
+  [9191] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(349), 17,
@@ -12434,7 +12569,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9238] = 3,
+  [9244] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(353), 17,
@@ -12484,7 +12619,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9291] = 3,
+  [9297] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(357), 17,
@@ -12534,7 +12669,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9344] = 4,
+  [9350] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(363), 1,
@@ -12585,7 +12720,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9399] = 3,
+  [9405] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(367), 17,
@@ -12635,7 +12770,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9452] = 3,
+  [9458] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(371), 17,
@@ -12685,7 +12820,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9505] = 3,
+  [9511] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(375), 17,
@@ -12735,7 +12870,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9558] = 3,
+  [9564] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(379), 17,
@@ -12785,7 +12920,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9611] = 3,
+  [9617] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(383), 17,
@@ -12835,7 +12970,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9664] = 3,
+  [9670] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(387), 17,
@@ -12885,7 +13020,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9717] = 3,
+  [9723] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(391), 17,
@@ -12935,7 +13070,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9770] = 3,
+  [9776] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(395), 17,
@@ -12985,7 +13120,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9823] = 3,
+  [9829] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(399), 17,
@@ -13035,7 +13170,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9876] = 3,
+  [9882] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(403), 17,
@@ -13085,7 +13220,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9929] = 3,
+  [9935] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(407), 17,
@@ -13135,7 +13270,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [9982] = 3,
+  [9988] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(411), 17,
@@ -13185,7 +13320,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10035] = 3,
+  [10041] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(415), 17,
@@ -13235,7 +13370,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10088] = 4,
+  [10094] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(363), 1,
@@ -13286,7 +13421,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10143] = 3,
+  [10149] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(423), 17,
@@ -13336,7 +13471,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10196] = 3,
+  [10202] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(427), 17,
@@ -13386,7 +13521,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10249] = 4,
+  [10255] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(363), 1,
@@ -13437,7 +13572,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10304] = 3,
+  [10310] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(435), 17,
@@ -13487,7 +13622,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10357] = 3,
+  [10363] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(439), 17,
@@ -13537,7 +13672,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10410] = 3,
+  [10416] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(443), 17,
@@ -13587,7 +13722,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10463] = 3,
+  [10469] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(447), 17,
@@ -13637,7 +13772,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10516] = 3,
+  [10522] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(451), 17,
@@ -13687,7 +13822,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10569] = 3,
+  [10575] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(455), 17,
@@ -13737,7 +13872,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10622] = 3,
+  [10628] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(459), 17,
@@ -13787,7 +13922,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10675] = 3,
+  [10681] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(463), 17,
@@ -13837,7 +13972,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10728] = 3,
+  [10734] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(467), 17,
@@ -13887,7 +14022,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10781] = 3,
+  [10787] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(471), 17,
@@ -13937,7 +14072,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10834] = 3,
+  [10840] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(475), 17,
@@ -13987,7 +14122,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10887] = 3,
+  [10893] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(479), 17,
@@ -14037,7 +14172,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10940] = 3,
+  [10946] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(483), 17,
@@ -14087,7 +14222,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [10993] = 3,
+  [10999] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(487), 17,
@@ -14137,7 +14272,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [11046] = 3,
+  [11052] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(491), 17,
@@ -14187,7 +14322,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [11099] = 3,
+  [11105] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(495), 17,
@@ -14237,7 +14372,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [11152] = 3,
+  [11158] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(499), 17,
@@ -14287,7 +14422,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [11205] = 3,
+  [11211] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(503), 16,
@@ -14336,7 +14471,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [11257] = 3,
+  [11263] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(507), 16,
@@ -14385,7 +14520,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [11309] = 32,
+  [11315] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -14420,7 +14555,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -14463,7 +14598,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [11419] = 32,
+  [11425] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -14541,7 +14676,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [11529] = 32,
+  [11535] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -14576,7 +14711,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -14619,7 +14754,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [11639] = 32,
+  [11645] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -14697,7 +14832,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [11749] = 32,
+  [11755] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -14775,7 +14910,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [11859] = 32,
+  [11865] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -14810,7 +14945,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -14853,7 +14988,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [11969] = 3,
+  [11975] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(511), 16,
@@ -14902,7 +15037,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [12021] = 32,
+  [12027] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -14980,7 +15115,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [12131] = 32,
+  [12137] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -15015,7 +15150,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -15058,7 +15193,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [12241] = 32,
+  [12247] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -15093,7 +15228,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -15136,7 +15271,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [12351] = 3,
+  [12357] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(361), 16,
@@ -15185,7 +15320,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [12403] = 32,
+  [12409] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -15220,7 +15355,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -15263,7 +15398,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [12513] = 3,
+  [12519] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(515), 16,
@@ -15312,7 +15447,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [12565] = 32,
+  [12571] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -15390,7 +15525,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [12675] = 32,
+  [12681] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -15468,7 +15603,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [12785] = 32,
+  [12791] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -15503,7 +15638,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -15546,7 +15681,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [12895] = 3,
+  [12901] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(519), 16,
@@ -15595,7 +15730,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [12947] = 32,
+  [12953] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -15673,7 +15808,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [13057] = 32,
+  [13063] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -15708,7 +15843,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -15751,7 +15886,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [13167] = 3,
+  [13173] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(523), 16,
@@ -15800,7 +15935,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [13219] = 32,
+  [13225] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -15835,7 +15970,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -15878,7 +16013,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [13329] = 32,
+  [13335] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -15956,7 +16091,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [13439] = 3,
+  [13445] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(527), 16,
@@ -16005,7 +16140,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [13491] = 32,
+  [13497] = 32,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -16040,7 +16175,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -16083,7 +16218,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [13601] = 30,
+  [13607] = 30,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -16157,7 +16292,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [13705] = 30,
+  [13711] = 30,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -16231,7 +16366,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [13809] = 29,
+  [13815] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -16264,7 +16399,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -16303,7 +16438,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [13910] = 29,
+  [13916] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -16336,7 +16471,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -16375,7 +16510,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [14011] = 29,
+  [14017] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -16408,7 +16543,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -16447,7 +16582,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [14112] = 29,
+  [14118] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -16480,7 +16615,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -16519,7 +16654,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [14213] = 29,
+  [14219] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -16552,7 +16687,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -16591,7 +16726,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [14314] = 29,
+  [14320] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -16624,7 +16759,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -16663,7 +16798,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [14415] = 29,
+  [14421] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -16696,7 +16831,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -16735,7 +16870,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [14516] = 29,
+  [14522] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -16768,7 +16903,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -16807,7 +16942,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [14617] = 29,
+  [14623] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -16840,7 +16975,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -16879,7 +17014,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [14718] = 29,
+  [14724] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -16951,7 +17086,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [14819] = 29,
+  [14825] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -17023,7 +17158,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [14920] = 29,
+  [14926] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -17095,7 +17230,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [15021] = 29,
+  [15027] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -17167,7 +17302,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [15122] = 29,
+  [15128] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -17239,7 +17374,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [15223] = 29,
+  [15229] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -17311,7 +17446,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [15324] = 29,
+  [15330] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -17383,7 +17518,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [15425] = 29,
+  [15431] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -17455,7 +17590,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [15526] = 29,
+  [15532] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -17527,7 +17662,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [15627] = 29,
+  [15633] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -17560,7 +17695,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -17599,7 +17734,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [15728] = 29,
+  [15734] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -17632,7 +17767,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -17671,7 +17806,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [15829] = 29,
+  [15835] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -17704,7 +17839,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -17743,7 +17878,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [15930] = 29,
+  [15936] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -17776,7 +17911,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -17815,7 +17950,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [16031] = 29,
+  [16037] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -17848,7 +17983,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -17887,7 +18022,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [16132] = 29,
+  [16138] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -17920,7 +18055,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -17959,7 +18094,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [16233] = 29,
+  [16239] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -17992,7 +18127,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -18031,7 +18166,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [16334] = 29,
+  [16340] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18064,7 +18199,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -18103,7 +18238,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [16435] = 29,
+  [16441] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18136,7 +18271,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -18175,7 +18310,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [16536] = 29,
+  [16542] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18208,7 +18343,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -18247,7 +18382,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [16637] = 29,
+  [16643] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18319,7 +18454,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [16738] = 29,
+  [16744] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18352,7 +18487,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -18391,7 +18526,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [16839] = 29,
+  [16845] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18424,7 +18559,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(285), 1,
       sym_quoted_enum_tag_start,
-    STATE(71), 1,
+    STATE(77), 1,
       sym_applicative,
     STATE(150), 1,
       sym_infix_u_op_5,
@@ -18463,7 +18598,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [16940] = 29,
+  [16946] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18496,7 +18631,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -18535,7 +18670,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [17041] = 29,
+  [17047] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18568,7 +18703,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -18607,7 +18742,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [17142] = 29,
+  [17148] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18640,7 +18775,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -18679,7 +18814,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [17243] = 29,
+  [17249] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18751,7 +18886,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [17344] = 29,
+  [17350] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18784,7 +18919,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -18823,7 +18958,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [17445] = 29,
+  [17451] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18856,7 +18991,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -18895,7 +19030,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [17546] = 29,
+  [17552] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -18928,7 +19063,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -18967,7 +19102,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [17647] = 29,
+  [17653] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19000,7 +19135,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -19039,7 +19174,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [17748] = 29,
+  [17754] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19072,7 +19207,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -19111,7 +19246,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [17849] = 29,
+  [17855] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19144,7 +19279,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -19183,7 +19318,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [17950] = 29,
+  [17956] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19216,7 +19351,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -19255,7 +19390,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [18051] = 29,
+  [18057] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19288,7 +19423,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(205), 1,
       sym_quoted_enum_tag_start,
-    STATE(73), 1,
+    STATE(79), 1,
       sym_applicative,
     STATE(179), 1,
       sym_infix_u_op_5,
@@ -19327,7 +19462,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [18152] = 29,
+  [18158] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19360,7 +19495,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -19399,7 +19534,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [18253] = 29,
+  [18259] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19432,7 +19567,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -19471,7 +19606,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [18354] = 29,
+  [18360] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19504,7 +19639,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -19543,7 +19678,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [18455] = 29,
+  [18461] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19576,7 +19711,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -19615,7 +19750,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [18556] = 29,
+  [18562] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19648,7 +19783,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -19687,7 +19822,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [18657] = 29,
+  [18663] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19720,7 +19855,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -19759,7 +19894,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [18758] = 29,
+  [18764] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19792,7 +19927,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -19831,7 +19966,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [18859] = 29,
+  [18865] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19864,7 +19999,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -19903,7 +20038,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [18960] = 29,
+  [18966] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -19936,7 +20071,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -19975,7 +20110,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [19061] = 29,
+  [19067] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20008,7 +20143,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -20047,7 +20182,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [19162] = 29,
+  [19168] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20080,7 +20215,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -20119,7 +20254,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [19263] = 29,
+  [19269] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20152,7 +20287,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -20191,7 +20326,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [19364] = 29,
+  [19370] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20224,7 +20359,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -20263,7 +20398,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [19465] = 29,
+  [19471] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20296,7 +20431,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -20335,7 +20470,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [19566] = 29,
+  [19572] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20368,7 +20503,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -20407,7 +20542,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [19667] = 29,
+  [19673] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20440,7 +20575,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -20479,7 +20614,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [19768] = 29,
+  [19774] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20512,7 +20647,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -20551,7 +20686,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [19869] = 29,
+  [19875] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20584,7 +20719,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -20623,7 +20758,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [19970] = 29,
+  [19976] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20656,7 +20791,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -20695,7 +20830,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [20071] = 29,
+  [20077] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20728,7 +20863,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(325), 1,
       sym_quoted_enum_tag_start,
-    STATE(70), 1,
+    STATE(73), 1,
       sym_applicative,
     STATE(205), 1,
       sym_infix_u_op_5,
@@ -20767,7 +20902,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [20172] = 29,
+  [20178] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20800,7 +20935,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -20839,7 +20974,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [20273] = 29,
+  [20279] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(39), 1,
@@ -20872,7 +21007,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(245), 1,
       sym_quoted_enum_tag_start,
-    STATE(69), 1,
+    STATE(70), 1,
       sym_applicative,
     STATE(197), 1,
       sym_infix_u_op_5,
@@ -20911,7 +21046,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [20374] = 29,
+  [20380] = 29,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -20944,7 +21079,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     ACTIONS(47), 1,
       sym_quoted_enum_tag_start,
-    STATE(72), 1,
+    STATE(78), 1,
       sym_applicative,
     STATE(212), 1,
       sym_infix_u_op_5,
@@ -20983,7 +21118,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [20475] = 3,
+  [20481] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(379), 16,
@@ -21027,7 +21162,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20522] = 3,
+  [20528] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(399), 16,
@@ -21071,7 +21206,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20569] = 3,
+  [20575] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(411), 17,
@@ -21115,7 +21250,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20616] = 3,
+  [20622] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(435), 16,
@@ -21159,7 +21294,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20663] = 3,
+  [20669] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(345), 16,
@@ -21203,7 +21338,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20710] = 3,
+  [20716] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(379), 16,
@@ -21247,7 +21382,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20757] = 3,
+  [20763] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(407), 17,
@@ -21291,7 +21426,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20804] = 3,
+  [20810] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(375), 17,
@@ -21335,7 +21470,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20851] = 3,
+  [20857] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(427), 16,
@@ -21379,7 +21514,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20898] = 3,
+  [20904] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(423), 16,
@@ -21423,7 +21558,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20945] = 3,
+  [20951] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(439), 16,
@@ -21467,7 +21602,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [20992] = 3,
+  [20998] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(371), 16,
@@ -21511,7 +21646,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21039] = 3,
+  [21045] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(451), 16,
@@ -21555,7 +21690,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21086] = 3,
+  [21092] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(443), 16,
@@ -21599,7 +21734,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21133] = 3,
+  [21139] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(367), 17,
@@ -21643,7 +21778,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21180] = 3,
+  [21186] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(357), 17,
@@ -21687,7 +21822,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21227] = 3,
+  [21233] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(353), 17,
@@ -21731,7 +21866,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21274] = 3,
+  [21280] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(349), 16,
@@ -21775,7 +21910,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21321] = 4,
+  [21327] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(533), 1,
@@ -21820,7 +21955,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21370] = 3,
+  [21376] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(403), 16,
@@ -21864,7 +21999,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21417] = 3,
+  [21423] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(403), 16,
@@ -21908,7 +22043,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21464] = 3,
+  [21470] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(467), 17,
@@ -21952,7 +22087,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21511] = 4,
+  [21517] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(535), 1,
@@ -21997,7 +22132,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21560] = 3,
+  [21566] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(463), 17,
@@ -22041,7 +22176,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21607] = 3,
+  [21613] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(491), 17,
@@ -22085,7 +22220,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21654] = 3,
+  [21660] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(447), 17,
@@ -22129,7 +22264,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21701] = 3,
+  [21707] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(383), 17,
@@ -22173,7 +22308,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21748] = 3,
+  [21754] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(391), 16,
@@ -22217,7 +22352,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21795] = 3,
+  [21801] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(387), 17,
@@ -22261,7 +22396,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21842] = 4,
+  [21848] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(537), 1,
@@ -22306,7 +22441,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21891] = 3,
+  [21897] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(427), 17,
@@ -22350,7 +22485,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21938] = 3,
+  [21944] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(423), 17,
@@ -22394,7 +22529,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [21985] = 4,
+  [21991] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(537), 1,
@@ -22439,7 +22574,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22034] = 3,
+  [22040] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(383), 16,
@@ -22483,7 +22618,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22081] = 3,
+  [22087] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(447), 16,
@@ -22527,7 +22662,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22128] = 3,
+  [22134] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(395), 16,
@@ -22571,7 +22706,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22175] = 3,
+  [22181] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(403), 17,
@@ -22615,7 +22750,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22222] = 3,
+  [22228] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(399), 17,
@@ -22659,7 +22794,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22269] = 3,
+  [22275] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(455), 16,
@@ -22703,7 +22838,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22316] = 3,
+  [22322] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(459), 16,
@@ -22747,7 +22882,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22363] = 3,
+  [22369] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(395), 16,
@@ -22791,7 +22926,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22410] = 3,
+  [22416] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(471), 16,
@@ -22835,7 +22970,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22457] = 3,
+  [22463] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(475), 17,
@@ -22879,7 +23014,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22504] = 3,
+  [22510] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(483), 16,
@@ -22923,7 +23058,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22551] = 3,
+  [22557] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(491), 16,
@@ -22967,7 +23102,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22598] = 3,
+  [22604] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(479), 17,
@@ -23011,7 +23146,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22645] = 3,
+  [22651] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(395), 17,
@@ -23055,7 +23190,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22692] = 3,
+  [22698] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(487), 17,
@@ -23099,7 +23234,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22739] = 3,
+  [22745] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(391), 17,
@@ -23143,7 +23278,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22786] = 4,
+  [22792] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(537), 1,
@@ -23188,7 +23323,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22835] = 3,
+  [22841] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(495), 17,
@@ -23232,7 +23367,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22882] = 3,
+  [22888] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(499), 17,
@@ -23276,7 +23411,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22929] = 3,
+  [22935] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(391), 16,
@@ -23320,7 +23455,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [22976] = 4,
+  [22982] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(535), 1,
@@ -23365,7 +23500,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23025] = 3,
+  [23031] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(495), 16,
@@ -23409,7 +23544,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23072] = 3,
+  [23078] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(451), 17,
@@ -23453,7 +23588,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23119] = 3,
+  [23125] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(499), 16,
@@ -23497,7 +23632,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23166] = 3,
+  [23172] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(371), 17,
@@ -23541,7 +23676,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23213] = 4,
+  [23219] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(533), 1,
@@ -23586,7 +23721,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23262] = 3,
+  [23268] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(345), 17,
@@ -23630,7 +23765,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23309] = 3,
+  [23315] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(379), 17,
@@ -23674,7 +23809,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23356] = 3,
+  [23362] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(379), 17,
@@ -23718,7 +23853,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23403] = 3,
+  [23409] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(371), 17,
@@ -23762,7 +23897,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23450] = 3,
+  [23456] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(451), 17,
@@ -23806,7 +23941,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23497] = 3,
+  [23503] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(379), 17,
@@ -23850,7 +23985,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23544] = 3,
+  [23550] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(479), 16,
@@ -23894,7 +24029,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23591] = 3,
+  [23597] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(345), 17,
@@ -23938,7 +24073,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23638] = 3,
+  [23644] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(499), 17,
@@ -23982,7 +24117,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23685] = 3,
+  [23691] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(387), 16,
@@ -24026,7 +24161,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23732] = 3,
+  [23738] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(495), 17,
@@ -24070,7 +24205,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23779] = 4,
+  [23785] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(539), 1,
@@ -24115,7 +24250,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23828] = 3,
+  [23834] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(391), 17,
@@ -24159,7 +24294,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23875] = 3,
+  [23881] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(487), 17,
@@ -24203,7 +24338,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23922] = 3,
+  [23928] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(491), 17,
@@ -24247,7 +24382,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [23969] = 3,
+  [23975] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(451), 16,
@@ -24291,7 +24426,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24016] = 3,
+  [24022] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(395), 17,
@@ -24335,7 +24470,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24063] = 3,
+  [24069] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(371), 16,
@@ -24379,7 +24514,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24110] = 3,
+  [24116] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(483), 17,
@@ -24423,7 +24558,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24157] = 3,
+  [24163] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(471), 17,
@@ -24467,7 +24602,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24204] = 3,
+  [24210] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(459), 17,
@@ -24511,7 +24646,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24251] = 3,
+  [24257] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(455), 17,
@@ -24555,7 +24690,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24298] = 3,
+  [24304] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(399), 17,
@@ -24599,7 +24734,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24345] = 3,
+  [24351] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(403), 17,
@@ -24643,7 +24778,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24392] = 3,
+  [24398] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(479), 17,
@@ -24687,7 +24822,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24439] = 4,
+  [24445] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(539), 1,
@@ -24732,7 +24867,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24488] = 3,
+  [24494] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(345), 16,
@@ -24776,7 +24911,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24535] = 3,
+  [24541] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(349), 17,
@@ -24820,7 +24955,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24582] = 3,
+  [24588] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(443), 17,
@@ -24864,7 +24999,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24629] = 3,
+  [24635] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(439), 17,
@@ -24908,7 +25043,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24676] = 3,
+  [24682] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(435), 17,
@@ -24952,7 +25087,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24723] = 3,
+  [24729] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(415), 17,
@@ -24996,7 +25131,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24770] = 3,
+  [24776] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(475), 17,
@@ -25040,7 +25175,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24817] = 3,
+  [24823] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(411), 17,
@@ -25084,7 +25219,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24864] = 3,
+  [24870] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(423), 17,
@@ -25128,7 +25263,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24911] = 3,
+  [24917] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(407), 17,
@@ -25172,7 +25307,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [24958] = 3,
+  [24964] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(427), 17,
@@ -25216,7 +25351,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25005] = 3,
+  [25011] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(375), 17,
@@ -25260,7 +25395,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25052] = 4,
+  [25058] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(539), 1,
@@ -25305,7 +25440,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25101] = 3,
+  [25107] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(367), 17,
@@ -25349,7 +25484,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25148] = 3,
+  [25154] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(357), 17,
@@ -25393,7 +25528,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25195] = 3,
+  [25201] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(415), 16,
@@ -25437,7 +25572,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25242] = 3,
+  [25248] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(353), 17,
@@ -25481,7 +25616,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25289] = 3,
+  [25295] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(467), 17,
@@ -25525,7 +25660,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25336] = 3,
+  [25342] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(463), 17,
@@ -25569,7 +25704,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25383] = 3,
+  [25389] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(399), 17,
@@ -25613,7 +25748,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25430] = 3,
+  [25436] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(387), 17,
@@ -25657,7 +25792,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25477] = 3,
+  [25483] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(447), 16,
@@ -25701,7 +25836,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25524] = 3,
+  [25530] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(383), 16,
@@ -25745,7 +25880,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25571] = 3,
+  [25577] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(387), 16,
@@ -25789,7 +25924,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25618] = 3,
+  [25624] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(475), 16,
@@ -25833,7 +25968,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25665] = 4,
+  [25671] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(541), 1,
@@ -25878,7 +26013,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25714] = 3,
+  [25720] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(427), 17,
@@ -25922,7 +26057,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25761] = 3,
+  [25767] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(423), 17,
@@ -25966,7 +26101,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25808] = 4,
+  [25814] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(541), 1,
@@ -26011,7 +26146,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25857] = 3,
+  [25863] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(447), 17,
@@ -26055,7 +26190,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25904] = 3,
+  [25910] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(383), 17,
@@ -26099,7 +26234,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25951] = 3,
+  [25957] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(447), 17,
@@ -26143,7 +26278,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [25998] = 3,
+  [26004] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(463), 17,
@@ -26187,7 +26322,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26045] = 3,
+  [26051] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(467), 17,
@@ -26231,7 +26366,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26092] = 3,
+  [26098] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(403), 17,
@@ -26275,7 +26410,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26139] = 3,
+  [26145] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(483), 17,
@@ -26319,7 +26454,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26186] = 3,
+  [26192] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(353), 17,
@@ -26363,7 +26498,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26233] = 3,
+  [26239] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(357), 17,
@@ -26407,7 +26542,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26280] = 3,
+  [26286] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(367), 17,
@@ -26451,7 +26586,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26327] = 3,
+  [26333] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(375), 17,
@@ -26495,7 +26630,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26374] = 3,
+  [26380] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(407), 17,
@@ -26539,7 +26674,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26421] = 3,
+  [26427] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(411), 17,
@@ -26583,7 +26718,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26468] = 3,
+  [26474] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(471), 17,
@@ -26627,7 +26762,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26515] = 3,
+  [26521] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(487), 16,
@@ -26671,7 +26806,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26562] = 4,
+  [26568] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(533), 1,
@@ -26716,7 +26851,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26611] = 3,
+  [26617] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(459), 17,
@@ -26760,7 +26895,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26658] = 3,
+  [26664] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(475), 16,
@@ -26804,7 +26939,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26705] = 3,
+  [26711] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(479), 16,
@@ -26848,7 +26983,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26752] = 3,
+  [26758] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(395), 17,
@@ -26892,7 +27027,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26799] = 3,
+  [26805] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(487), 16,
@@ -26936,7 +27071,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26846] = 3,
+  [26852] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(391), 17,
@@ -26980,7 +27115,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26893] = 4,
+  [26899] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(541), 1,
@@ -27025,7 +27160,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26942] = 4,
+  [26948] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(535), 1,
@@ -27070,7 +27205,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [26991] = 3,
+  [26997] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(455), 17,
@@ -27114,7 +27249,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27038] = 3,
+  [27044] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(415), 17,
@@ -27158,7 +27293,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27085] = 3,
+  [27091] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(423), 16,
@@ -27202,7 +27337,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27132] = 3,
+  [27138] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(451), 17,
@@ -27246,7 +27381,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27179] = 3,
+  [27185] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(371), 17,
@@ -27290,7 +27425,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27226] = 3,
+  [27232] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(463), 16,
@@ -27334,7 +27469,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27273] = 3,
+  [27279] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(415), 17,
@@ -27378,7 +27513,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27320] = 3,
+  [27326] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(435), 17,
@@ -27422,7 +27557,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27367] = 3,
+  [27373] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(427), 16,
@@ -27466,7 +27601,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27414] = 3,
+  [27420] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(349), 17,
@@ -27510,7 +27645,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27461] = 3,
+  [27467] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(439), 17,
@@ -27554,7 +27689,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27508] = 3,
+  [27514] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(443), 17,
@@ -27598,7 +27733,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27555] = 3,
+  [27561] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(349), 17,
@@ -27642,7 +27777,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27602] = 3,
+  [27608] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(435), 17,
@@ -27686,7 +27821,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27649] = 3,
+  [27655] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(399), 16,
@@ -27730,7 +27865,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27696] = 3,
+  [27702] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(443), 17,
@@ -27774,7 +27909,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27743] = 3,
+  [27749] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(463), 16,
@@ -27818,7 +27953,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27790] = 3,
+  [27796] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(455), 17,
@@ -27862,7 +27997,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27837] = 3,
+  [27843] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(459), 17,
@@ -27906,7 +28041,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27884] = 3,
+  [27890] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(471), 17,
@@ -27950,7 +28085,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27931] = 3,
+  [27937] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(467), 16,
@@ -27994,7 +28129,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [27978] = 3,
+  [27984] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(483), 17,
@@ -28038,7 +28173,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28025] = 3,
+  [28031] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(491), 17,
@@ -28082,7 +28217,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28072] = 3,
+  [28078] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(467), 16,
@@ -28126,7 +28261,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28119] = 3,
+  [28125] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(495), 17,
@@ -28170,7 +28305,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28166] = 3,
+  [28172] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(353), 16,
@@ -28214,7 +28349,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28213] = 3,
+  [28219] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(499), 17,
@@ -28258,7 +28393,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28260] = 3,
+  [28266] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(357), 16,
@@ -28302,7 +28437,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28307] = 3,
+  [28313] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(367), 16,
@@ -28346,7 +28481,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28354] = 3,
+  [28360] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(375), 16,
@@ -28390,7 +28525,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28401] = 3,
+  [28407] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(353), 16,
@@ -28434,7 +28569,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28448] = 3,
+  [28454] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(357), 16,
@@ -28478,7 +28613,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28495] = 3,
+  [28501] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(407), 16,
@@ -28522,7 +28657,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28542] = 3,
+  [28548] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(345), 17,
@@ -28566,7 +28701,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28589] = 3,
+  [28595] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(499), 16,
@@ -28610,7 +28745,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28636] = 3,
+  [28642] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(495), 16,
@@ -28654,7 +28789,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28683] = 3,
+  [28689] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(383), 17,
@@ -28698,7 +28833,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28730] = 3,
+  [28736] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(491), 16,
@@ -28742,7 +28877,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28777] = 3,
+  [28783] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(487), 17,
@@ -28786,7 +28921,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28824] = 3,
+  [28830] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(483), 16,
@@ -28830,7 +28965,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28871] = 3,
+  [28877] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(387), 17,
@@ -28874,7 +29009,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28918] = 3,
+  [28924] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(479), 17,
@@ -28918,7 +29053,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [28965] = 3,
+  [28971] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(411), 16,
@@ -28962,7 +29097,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29012] = 3,
+  [29018] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(475), 17,
@@ -29006,7 +29141,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29059] = 3,
+  [29065] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(471), 16,
@@ -29050,7 +29185,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29106] = 3,
+  [29112] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(459), 16,
@@ -29094,7 +29229,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29153] = 3,
+  [29159] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(455), 16,
@@ -29138,7 +29273,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29200] = 3,
+  [29206] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(367), 16,
@@ -29182,7 +29317,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29247] = 3,
+  [29253] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(349), 16,
@@ -29226,7 +29361,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29294] = 3,
+  [29300] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(439), 17,
@@ -29270,7 +29405,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29341] = 3,
+  [29347] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(443), 16,
@@ -29314,7 +29449,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29388] = 3,
+  [29394] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(439), 16,
@@ -29358,7 +29493,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29435] = 3,
+  [29441] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(415), 16,
@@ -29402,7 +29537,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29482] = 3,
+  [29488] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(435), 16,
@@ -29446,7 +29581,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29529] = 3,
+  [29535] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(411), 16,
@@ -29490,7 +29625,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29576] = 3,
+  [29582] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(407), 16,
@@ -29534,7 +29669,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29623] = 3,
+  [29629] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(375), 16,
@@ -29578,7 +29713,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29670] = 3,
+  [29676] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(511), 15,
@@ -29621,7 +29756,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29716] = 3,
+  [29722] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(519), 16,
@@ -29664,7 +29799,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29762] = 3,
+  [29768] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(519), 15,
@@ -29707,7 +29842,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29808] = 3,
+  [29814] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(503), 15,
@@ -29750,7 +29885,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29854] = 3,
+  [29860] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(507), 15,
@@ -29793,7 +29928,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29900] = 3,
+  [29906] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(361), 15,
@@ -29836,7 +29971,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29946] = 3,
+  [29952] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(527), 16,
@@ -29879,7 +30014,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [29992] = 3,
+  [29998] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(515), 15,
@@ -29922,7 +30057,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30038] = 3,
+  [30044] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(523), 15,
@@ -29965,7 +30100,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30084] = 3,
+  [30090] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(511), 16,
@@ -30008,7 +30143,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30130] = 3,
+  [30136] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(515), 16,
@@ -30051,7 +30186,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30176] = 3,
+  [30182] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(507), 15,
@@ -30094,7 +30229,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30222] = 3,
+  [30228] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(523), 16,
@@ -30137,7 +30272,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30268] = 3,
+  [30274] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(527), 15,
@@ -30180,7 +30315,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30314] = 3,
+  [30320] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(361), 16,
@@ -30223,7 +30358,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30360] = 3,
+  [30366] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(523), 15,
@@ -30266,7 +30401,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30406] = 3,
+  [30412] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(527), 15,
@@ -30309,7 +30444,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30452] = 3,
+  [30458] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(515), 16,
@@ -30352,7 +30487,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30498] = 3,
+  [30504] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(515), 15,
@@ -30395,7 +30530,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30544] = 3,
+  [30550] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(507), 16,
@@ -30438,7 +30573,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30590] = 3,
+  [30596] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(511), 15,
@@ -30481,7 +30616,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30636] = 3,
+  [30642] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(361), 15,
@@ -30524,7 +30659,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30682] = 3,
+  [30688] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(361), 16,
@@ -30567,7 +30702,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30728] = 3,
+  [30734] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(503), 16,
@@ -30610,7 +30745,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30774] = 3,
+  [30780] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(515), 16,
@@ -30653,7 +30788,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30820] = 3,
+  [30826] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(507), 16,
@@ -30696,7 +30831,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30866] = 3,
+  [30872] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(523), 16,
@@ -30739,7 +30874,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30912] = 3,
+  [30918] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(361), 16,
@@ -30782,7 +30917,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [30958] = 3,
+  [30964] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(519), 16,
@@ -30825,7 +30960,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31004] = 3,
+  [31010] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(507), 16,
@@ -30868,7 +31003,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31050] = 3,
+  [31056] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(527), 16,
@@ -30911,7 +31046,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31096] = 3,
+  [31102] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(503), 15,
@@ -30954,7 +31089,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31142] = 3,
+  [31148] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(503), 16,
@@ -30997,7 +31132,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31188] = 3,
+  [31194] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(519), 16,
@@ -31040,7 +31175,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31234] = 3,
+  [31240] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(503), 16,
@@ -31083,7 +31218,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31280] = 3,
+  [31286] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(527), 16,
@@ -31126,7 +31261,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31326] = 3,
+  [31332] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(511), 16,
@@ -31169,7 +31304,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31372] = 3,
+  [31378] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(523), 16,
@@ -31212,7 +31347,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31418] = 3,
+  [31424] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(511), 16,
@@ -31255,7 +31390,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31464] = 3,
+  [31470] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(519), 15,
@@ -31298,7 +31433,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
       anon_sym_LBRACK_PIPE,
-  [31510] = 26,
+  [31516] = 26,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(543), 1,
@@ -31363,7 +31498,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SEMI,
       anon_sym_RPAREN,
       anon_sym_RBRACK,
-  [31601] = 12,
+  [31607] = 12,
     ACTIONS(3), 1,
       sym_comment,
     STATE(156), 1,
@@ -31412,7 +31547,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [31662] = 18,
+  [31668] = 18,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -31467,7 +31602,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [31735] = 19,
+  [31741] = 19,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -31523,7 +31658,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [31810] = 14,
+  [31816] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(156), 1,
@@ -31574,7 +31709,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [31875] = 11,
+  [31881] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(156), 1,
@@ -31622,7 +31757,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [31934] = 22,
+  [31940] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -31681,7 +31816,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [32015] = 22,
+  [32021] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -31740,7 +31875,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [32096] = 16,
+  [32102] = 16,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -31793,7 +31928,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [32165] = 13,
+  [32171] = 13,
     ACTIONS(3), 1,
       sym_comment,
     STATE(156), 1,
@@ -31843,7 +31978,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [32228] = 14,
+  [32234] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(156), 1,
@@ -31894,7 +32029,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [32293] = 11,
+  [32299] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(156), 1,
@@ -31942,7 +32077,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [32352] = 20,
+  [32358] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -31999,7 +32134,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_QMARK,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [32429] = 25,
+  [32435] = 25,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(549), 1,
@@ -32058,7 +32193,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [32513] = 25,
+  [32519] = 25,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(549), 1,
@@ -32117,7 +32252,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [32597] = 25,
+  [32603] = 25,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(549), 1,
@@ -32176,7 +32311,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [32681] = 25,
+  [32687] = 25,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(549), 1,
@@ -32235,7 +32370,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [32765] = 25,
+  [32771] = 25,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(549), 1,
@@ -32294,7 +32429,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [32849] = 20,
+  [32855] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(207), 1,
@@ -32347,7 +32482,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [32922] = 20,
+  [32928] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(49), 1,
@@ -32400,7 +32535,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [32995] = 20,
+  [33001] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(287), 1,
@@ -32453,7 +32588,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [33068] = 20,
+  [33074] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(167), 1,
@@ -32506,7 +32641,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [33141] = 20,
+  [33147] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(5), 1,
@@ -32559,7 +32694,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [33214] = 20,
+  [33220] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(247), 1,
@@ -32612,7 +32747,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
       sym_builtin,
       sym_type_atom,
-  [33287] = 14,
+  [33293] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(152), 1,
@@ -32657,7 +32792,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [33346] = 22,
+  [33352] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -32710,7 +32845,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [33421] = 20,
+  [33427] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -32761,7 +32896,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_in,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [33492] = 22,
+  [33498] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -32814,7 +32949,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [33567] = 19,
+  [33573] = 19,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -32864,7 +32999,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [33636] = 18,
+  [33642] = 18,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -32913,7 +33048,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [33703] = 20,
+  [33709] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -32964,7 +33099,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_else,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [33774] = 14,
+  [33780] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(147), 1,
@@ -33009,7 +33144,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [33833] = 22,
+  [33839] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33062,7 +33197,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [33908] = 16,
+  [33914] = 16,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33109,7 +33244,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [33971] = 19,
+  [33977] = 19,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33159,7 +33294,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34040] = 14,
+  [34046] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(182), 1,
@@ -33204,7 +33339,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34099] = 18,
+  [34105] = 18,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33253,7 +33388,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34166] = 16,
+  [34172] = 16,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33300,7 +33435,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34229] = 11,
+  [34235] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(191), 1,
@@ -33342,7 +33477,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34282] = 14,
+  [34288] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(191), 1,
@@ -33387,7 +33522,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34341] = 22,
+  [34347] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33440,7 +33575,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [34416] = 11,
+  [34422] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(191), 1,
@@ -33482,7 +33617,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34469] = 12,
+  [34475] = 12,
     ACTIONS(3), 1,
       sym_comment,
     STATE(191), 1,
@@ -33525,7 +33660,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34524] = 11,
+  [34530] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(147), 1,
@@ -33567,7 +33702,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34577] = 13,
+  [34583] = 13,
     ACTIONS(3), 1,
       sym_comment,
     STATE(191), 1,
@@ -33611,7 +33746,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34634] = 14,
+  [34640] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(191), 1,
@@ -33656,7 +33791,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34693] = 14,
+  [34699] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(201), 1,
@@ -33701,7 +33836,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34752] = 16,
+  [34758] = 16,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33748,7 +33883,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34815] = 18,
+  [34821] = 18,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33797,7 +33932,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34882] = 19,
+  [34888] = 19,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33847,7 +33982,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [34951] = 20,
+  [34957] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33898,7 +34033,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_then,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35022] = 22,
+  [35028] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -33951,7 +34086,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [35097] = 22,
+  [35103] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -34004,7 +34139,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [35172] = 22,
+  [35178] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -34057,7 +34192,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [35247] = 13,
+  [35253] = 13,
     ACTIONS(3), 1,
       sym_comment,
     STATE(201), 1,
@@ -34101,7 +34236,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35304] = 13,
+  [35310] = 13,
     ACTIONS(3), 1,
       sym_comment,
     STATE(182), 1,
@@ -34145,7 +34280,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35361] = 12,
+  [35367] = 12,
     ACTIONS(3), 1,
       sym_comment,
     STATE(182), 1,
@@ -34188,7 +34323,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35416] = 12,
+  [35422] = 12,
     ACTIONS(3), 1,
       sym_comment,
     STATE(201), 1,
@@ -34231,7 +34366,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35471] = 11,
+  [35477] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(182), 1,
@@ -34273,7 +34408,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35524] = 11,
+  [35530] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(201), 1,
@@ -34315,7 +34450,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35577] = 14,
+  [35583] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(201), 1,
@@ -34360,7 +34495,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35636] = 11,
+  [35642] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(201), 1,
@@ -34402,7 +34537,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35689] = 22,
+  [35695] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -34455,7 +34590,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [35764] = 11,
+  [35770] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(152), 1,
@@ -34497,7 +34632,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35817] = 11,
+  [35823] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(147), 1,
@@ -34539,7 +34674,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35870] = 12,
+  [35876] = 12,
     ACTIONS(3), 1,
       sym_comment,
     STATE(147), 1,
@@ -34582,7 +34717,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35925] = 13,
+  [35931] = 13,
     ACTIONS(3), 1,
       sym_comment,
     STATE(147), 1,
@@ -34626,7 +34761,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [35982] = 14,
+  [35988] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(147), 1,
@@ -34671,7 +34806,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36041] = 16,
+  [36047] = 16,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -34718,7 +34853,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36104] = 18,
+  [36110] = 18,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -34767,7 +34902,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36171] = 19,
+  [36177] = 19,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -34817,7 +34952,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36240] = 20,
+  [36246] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -34868,7 +35003,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COLON,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36311] = 14,
+  [36317] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(182), 1,
@@ -34913,7 +35048,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36370] = 22,
+  [36376] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -34966,7 +35101,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [36445] = 22,
+  [36451] = 22,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -35019,7 +35154,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_STAR,
       anon_sym_SLASH,
-  [36520] = 11,
+  [36526] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(182), 1,
@@ -35061,7 +35196,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36573] = 11,
+  [36579] = 11,
     ACTIONS(3), 1,
       sym_comment,
     STATE(152), 1,
@@ -35103,7 +35238,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36626] = 12,
+  [36632] = 12,
     ACTIONS(3), 1,
       sym_comment,
     STATE(152), 1,
@@ -35146,7 +35281,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36681] = 20,
+  [36687] = 20,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -35197,7 +35332,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COLON,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36752] = 19,
+  [36758] = 19,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -35247,7 +35382,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36821] = 18,
+  [36827] = 18,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -35296,7 +35431,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36888] = 16,
+  [36894] = 16,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(557), 1,
@@ -35343,7 +35478,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [36951] = 14,
+  [36957] = 14,
     ACTIONS(3), 1,
       sym_comment,
     STATE(152), 1,
@@ -35388,7 +35523,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [37010] = 13,
+  [37016] = 13,
     ACTIONS(3), 1,
       sym_comment,
     STATE(152), 1,
@@ -35432,7 +35567,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_DASH_GT,
-  [37067] = 3,
+  [37073] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(615), 11,
@@ -35464,7 +35599,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37102] = 3,
+  [37108] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(619), 11,
@@ -35496,7 +35631,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37137] = 3,
+  [37143] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(623), 11,
@@ -35528,7 +35663,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37172] = 3,
+  [37178] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(627), 11,
@@ -35560,7 +35695,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37207] = 3,
+  [37213] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(631), 12,
@@ -35589,7 +35724,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37239] = 3,
+  [37245] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(635), 11,
@@ -35617,7 +35752,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37270] = 3,
+  [37276] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(531), 11,
@@ -35645,7 +35780,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37301] = 3,
+  [37307] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(641), 11,
@@ -35673,7 +35808,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37332] = 3,
+  [37338] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(645), 11,
@@ -35701,7 +35836,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37363] = 3,
+  [37369] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(649), 11,
@@ -35729,7 +35864,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37394] = 3,
+  [37400] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(653), 11,
@@ -35757,7 +35892,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37425] = 3,
+  [37431] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(657), 11,
@@ -35785,7 +35920,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37456] = 3,
+  [37462] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(661), 11,
@@ -35813,7 +35948,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Num,
       anon_sym_Bool,
       anon_sym_Str,
-  [37487] = 15,
+  [37493] = 15,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -35845,7 +35980,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37534] = 15,
+  [37540] = 15,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -35877,7 +36012,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37581] = 15,
+  [37587] = 15,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -35909,7 +36044,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37628] = 15,
+  [37634] = 15,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -35941,7 +36076,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37675] = 15,
+  [37681] = 15,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -35973,7 +36108,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37722] = 15,
+  [37728] = 15,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -36005,7 +36140,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37769] = 14,
+  [37775] = 14,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -36035,7 +36170,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37813] = 14,
+  [37819] = 14,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -36065,7 +36200,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37857] = 14,
+  [37863] = 14,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -36095,7 +36230,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37901] = 14,
+  [37907] = 14,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -36125,7 +36260,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37945] = 14,
+  [37951] = 14,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -36155,7 +36290,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [37989] = 14,
+  [37995] = 14,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -36185,7 +36320,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [38033] = 2,
+  [38039] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(525), 13,
@@ -36202,7 +36337,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38052] = 2,
+  [38058] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(733), 13,
@@ -36219,7 +36354,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38071] = 2,
+  [38077] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(735), 13,
@@ -36236,7 +36371,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38090] = 2,
+  [38096] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(737), 13,
@@ -36253,7 +36388,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38109] = 2,
+  [38115] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(501), 13,
@@ -36270,7 +36405,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38128] = 2,
+  [38134] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(739), 13,
@@ -36287,7 +36422,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38147] = 11,
+  [38153] = 11,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(741), 1,
@@ -36313,7 +36448,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_SEMI,
       anon_sym_DOT_DOT,
-  [38184] = 2,
+  [38190] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(752), 13,
@@ -36330,7 +36465,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38203] = 2,
+  [38209] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(583), 13,
@@ -36347,7 +36482,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38222] = 2,
+  [38228] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(754), 13,
@@ -36364,7 +36499,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38241] = 5,
+  [38247] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(545), 1,
@@ -36382,7 +36517,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38264] = 5,
+  [38270] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(760), 1,
@@ -36400,7 +36535,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_RBRACK,
       anon_sym_QMARK,
-  [38287] = 7,
+  [38293] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36419,7 +36554,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38313] = 7,
+  [38319] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36438,7 +36573,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38339] = 9,
+  [38345] = 9,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(545), 1,
@@ -36459,7 +36594,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(567), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [38369] = 2,
+  [38375] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(784), 10,
@@ -36473,7 +36608,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SEMI,
       anon_sym_RPAREN,
       anon_sym_RBRACK,
-  [38385] = 7,
+  [38391] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36492,7 +36627,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38411] = 2,
+  [38417] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(549), 10,
@@ -36506,7 +36641,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SEMI,
       anon_sym_RPAREN,
       anon_sym_RBRACK,
-  [38427] = 7,
+  [38433] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36525,7 +36660,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38453] = 7,
+  [38459] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36544,7 +36679,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38479] = 2,
+  [38485] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(792), 10,
@@ -36558,7 +36693,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SEMI,
       anon_sym_RPAREN,
       anon_sym_RBRACK,
-  [38495] = 7,
+  [38501] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36577,7 +36712,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38521] = 7,
+  [38527] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36596,7 +36731,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38547] = 7,
+  [38553] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36615,7 +36750,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38573] = 7,
+  [38579] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(800), 1,
@@ -36634,7 +36769,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38599] = 7,
+  [38605] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36653,7 +36788,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38625] = 7,
+  [38631] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36672,7 +36807,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38651] = 7,
+  [38657] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36691,7 +36826,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38677] = 2,
+  [38683] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(817), 10,
@@ -36705,7 +36840,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SEMI,
       anon_sym_RPAREN,
       anon_sym_RBRACK,
-  [38693] = 7,
+  [38699] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36724,7 +36859,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38719] = 2,
+  [38725] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(821), 10,
@@ -36738,7 +36873,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SEMI,
       anon_sym_RPAREN,
       anon_sym_RBRACK,
-  [38735] = 2,
+  [38741] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(823), 10,
@@ -36752,7 +36887,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SEMI,
       anon_sym_RPAREN,
       anon_sym_RBRACK,
-  [38751] = 7,
+  [38757] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36771,7 +36906,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38777] = 7,
+  [38783] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(768), 1,
@@ -36790,7 +36925,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_multi,
       aux_sym_str_chunks_multi_repeat1,
-  [38803] = 8,
+  [38809] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -36809,7 +36944,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [38830] = 8,
+  [38836] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -36828,7 +36963,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [38857] = 7,
+  [38863] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(545), 1,
@@ -36846,7 +36981,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-  [38882] = 8,
+  [38888] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -36865,7 +37000,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [38909] = 8,
+  [38915] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -36884,7 +37019,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [38936] = 8,
+  [38942] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -36903,7 +37038,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [38963] = 8,
+  [38969] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -36922,7 +37057,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [38990] = 8,
+  [38996] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -36941,7 +37076,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [39017] = 8,
+  [39023] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -36960,7 +37095,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [39044] = 8,
+  [39050] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -36979,7 +37114,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [39071] = 8,
+  [39077] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -36998,7 +37133,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [39098] = 8,
+  [39104] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -37017,7 +37152,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [39125] = 4,
+  [39131] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(865), 1,
@@ -37032,7 +37167,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [39144] = 8,
+  [39150] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -37051,7 +37186,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [39171] = 8,
+  [39177] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -37070,7 +37205,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [39198] = 8,
+  [39204] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(829), 1,
@@ -37089,7 +37224,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [39225] = 8,
+  [39231] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(875), 1,
@@ -37108,7 +37243,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_chunk_expr,
       sym_chunk_literal_single,
       aux_sym_str_chunks_single_repeat1,
-  [39252] = 6,
+  [39258] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37124,7 +37259,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39274] = 6,
+  [39280] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37140,7 +37275,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39296] = 4,
+  [39302] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(899), 1,
@@ -37154,7 +37289,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-  [39314] = 3,
+  [39320] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(903), 1,
@@ -37167,7 +37302,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [39330] = 6,
+  [39336] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37183,7 +37318,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39352] = 9,
+  [39358] = 9,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37202,7 +37337,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [39380] = 6,
+  [39386] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(917), 1,
@@ -37218,7 +37353,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39402] = 3,
+  [39408] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(927), 1,
@@ -37231,7 +37366,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [39418] = 6,
+  [39424] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37247,7 +37382,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39440] = 6,
+  [39446] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37263,7 +37398,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39462] = 6,
+  [39468] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37279,7 +37414,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39484] = 9,
+  [39490] = 9,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37298,7 +37433,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [39512] = 6,
+  [39518] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37314,7 +37449,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39534] = 3,
+  [39540] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(943), 1,
@@ -37327,7 +37462,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [39550] = 3,
+  [39556] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(947), 1,
@@ -37340,7 +37475,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [39566] = 4,
+  [39572] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(951), 1,
@@ -37354,7 +37489,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-  [39584] = 6,
+  [39590] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37370,7 +37505,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39606] = 4,
+  [39612] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(899), 1,
@@ -37384,7 +37519,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-  [39624] = 9,
+  [39630] = 9,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37403,7 +37538,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [39652] = 6,
+  [39658] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37419,7 +37554,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39674] = 9,
+  [39680] = 9,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37438,7 +37573,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [39702] = 6,
+  [39708] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37454,7 +37589,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39724] = 6,
+  [39730] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37470,7 +37605,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39746] = 6,
+  [39752] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37486,7 +37621,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39768] = 6,
+  [39774] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37502,7 +37637,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39790] = 6,
+  [39796] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37518,7 +37653,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39812] = 6,
+  [39818] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37534,7 +37669,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39834] = 9,
+  [39840] = 9,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37553,7 +37688,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [39862] = 3,
+  [39868] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(986), 1,
@@ -37566,7 +37701,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [39878] = 6,
+  [39884] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(889), 1,
@@ -37582,7 +37717,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [39900] = 3,
+  [39906] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(992), 1,
@@ -37595,7 +37730,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [39916] = 9,
+  [39922] = 9,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37614,7 +37749,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [39944] = 7,
+  [39950] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -37630,7 +37765,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(654), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [39967] = 7,
+  [39973] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(968), 1,
@@ -37646,7 +37781,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [39990] = 7,
+  [39996] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -37662,7 +37797,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(688), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40013] = 8,
+  [40019] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37679,7 +37814,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40038] = 8,
+  [40044] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37696,7 +37831,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40063] = 8,
+  [40069] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37713,7 +37848,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40088] = 7,
+  [40094] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(905), 1,
@@ -37729,7 +37864,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40111] = 7,
+  [40117] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -37745,7 +37880,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(648), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40134] = 7,
+  [40140] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -37761,7 +37896,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40157] = 7,
+  [40163] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(929), 1,
@@ -37777,7 +37912,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(657), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40180] = 2,
+  [40186] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1018), 7,
@@ -37788,7 +37923,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_DOT,
       anon_sym_SEMI,
-  [40193] = 2,
+  [40199] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(381), 7,
@@ -37799,7 +37934,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_DOT,
       anon_sym_SEMI,
-  [40206] = 7,
+  [40212] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(931), 1,
@@ -37815,7 +37950,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(646), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40229] = 2,
+  [40235] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(385), 7,
@@ -37826,7 +37961,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_DOT,
       anon_sym_SEMI,
-  [40242] = 7,
+  [40248] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -37842,7 +37977,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40265] = 7,
+  [40271] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1022), 1,
@@ -37858,7 +37993,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40288] = 7,
+  [40294] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(933), 1,
@@ -37874,7 +38009,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(675), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40311] = 7,
+  [40317] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(939), 1,
@@ -37890,7 +38025,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40334] = 7,
+  [40340] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -37906,7 +38041,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40357] = 8,
+  [40363] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37923,7 +38058,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40382] = 8,
+  [40388] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37940,7 +38075,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40407] = 7,
+  [40413] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(978), 1,
@@ -37956,7 +38091,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40430] = 8,
+  [40436] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37973,7 +38108,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40455] = 8,
+  [40461] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -37990,7 +38125,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40480] = 8,
+  [40486] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38007,7 +38142,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40505] = 7,
+  [40511] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(976), 1,
@@ -38023,7 +38158,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(661), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40528] = 7,
+  [40534] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -38039,7 +38174,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(674), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40551] = 7,
+  [40557] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(954), 1,
@@ -38055,7 +38190,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40574] = 7,
+  [40580] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -38071,7 +38206,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40597] = 2,
+  [40603] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(473), 7,
@@ -38082,7 +38217,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_DOT,
       anon_sym_SEMI,
-  [40610] = 7,
+  [40616] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -38098,7 +38233,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(682), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40633] = 8,
+  [40639] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38115,7 +38250,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40658] = 8,
+  [40664] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38132,7 +38267,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40683] = 7,
+  [40689] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -38148,7 +38283,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(668), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40706] = 7,
+  [40712] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -38164,7 +38299,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40729] = 7,
+  [40735] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(893), 1,
@@ -38180,7 +38315,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40752] = 8,
+  [40758] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38197,7 +38332,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40777] = 7,
+  [40783] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(962), 1,
@@ -38213,7 +38348,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(667), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40800] = 8,
+  [40806] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38230,7 +38365,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [40825] = 7,
+  [40831] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(988), 1,
@@ -38246,7 +38381,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(686), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40848] = 7,
+  [40854] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(665), 1,
@@ -38262,7 +38397,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(685), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [40871] = 2,
+  [40877] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(477), 7,
@@ -38273,7 +38408,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_DOT,
       anon_sym_SEMI,
-  [40884] = 7,
+  [40890] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -38289,7 +38424,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40907] = 7,
+  [40913] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(895), 1,
@@ -38305,7 +38440,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40930] = 7,
+  [40936] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(972), 1,
@@ -38321,7 +38456,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(641), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40953] = 2,
+  [40959] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(485), 7,
@@ -38332,7 +38467,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_DOT,
       anon_sym_SEMI,
-  [40966] = 7,
+  [40972] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(970), 1,
@@ -38348,7 +38483,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [40989] = 2,
+  [40995] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(949), 7,
@@ -38359,7 +38494,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_DOT,
       anon_sym_SEMI,
-  [41002] = 7,
+  [41008] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -38375,7 +38510,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(655), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [41025] = 7,
+  [41031] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(998), 1,
@@ -38391,7 +38526,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(658), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [41048] = 7,
+  [41054] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(974), 1,
@@ -38407,7 +38542,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(683), 2,
       sym_chunk_literal_single,
       aux_sym_static_string_repeat1,
-  [41071] = 7,
+  [41077] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1069), 1,
@@ -38422,7 +38557,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match,
     STATE(932), 1,
       sym_last_match,
-  [41093] = 6,
+  [41099] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(201), 1,
@@ -38436,7 +38571,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(260), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [41113] = 3,
+  [41119] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1079), 2,
@@ -38447,7 +38582,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [41127] = 6,
+  [41133] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -38461,7 +38596,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(717), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41147] = 6,
+  [41153] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(321), 1,
@@ -38475,7 +38610,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(389), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [41167] = 7,
+  [41173] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38490,7 +38625,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
     STATE(766), 1,
       sym_quoted_enum_tag,
-  [41189] = 6,
+  [41195] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -38504,7 +38639,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(717), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41209] = 6,
+  [41215] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -38518,7 +38653,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(717), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41229] = 6,
+  [41235] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(105), 1,
@@ -38532,7 +38667,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(115), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [41249] = 7,
+  [41255] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38547,7 +38682,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match_case,
     STATE(913), 1,
       sym_enum_tag,
-  [41271] = 6,
+  [41277] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(43), 1,
@@ -38561,7 +38696,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(341), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [41291] = 7,
+  [41297] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1069), 1,
@@ -38576,7 +38711,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_match,
     STATE(928), 1,
       sym_last_match,
-  [41313] = 7,
+  [41319] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38591,7 +38726,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
     STATE(766), 1,
       sym_quoted_enum_tag,
-  [41335] = 6,
+  [41341] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(281), 1,
@@ -38605,7 +38740,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(347), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [41355] = 7,
+  [41361] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38620,7 +38755,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
     STATE(766), 1,
       sym_quoted_enum_tag,
-  [41377] = 3,
+  [41383] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1115), 2,
@@ -38631,7 +38766,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [41391] = 2,
+  [41397] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(744), 6,
@@ -38641,7 +38776,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
       anon_sym_SEMI,
       anon_sym_DOT_DOT,
-  [41403] = 6,
+  [41409] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -38655,7 +38790,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(717), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41423] = 7,
+  [41429] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38670,7 +38805,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
     STATE(766), 1,
       sym_quoted_enum_tag,
-  [41445] = 6,
+  [41451] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -38684,7 +38819,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(717), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41465] = 7,
+  [41471] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38699,7 +38834,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
     STATE(766), 1,
       sym_quoted_enum_tag,
-  [41487] = 6,
+  [41493] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(545), 1,
@@ -38713,7 +38848,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(567), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41507] = 7,
+  [41513] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -38728,7 +38863,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_enum_tag,
     STATE(766), 1,
       sym_quoted_enum_tag,
-  [41529] = 3,
+  [41535] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1137), 2,
@@ -38739,7 +38874,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [41543] = 6,
+  [41549] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -38753,7 +38888,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(717), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41563] = 6,
+  [41569] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(545), 1,
@@ -38767,7 +38902,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(567), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41583] = 6,
+  [41589] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1143), 1,
@@ -38781,7 +38916,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(717), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41603] = 6,
+  [41609] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(241), 1,
@@ -38795,7 +38930,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(285), 2,
       sym_str_chunks_single,
       sym_str_chunks_multi,
-  [41623] = 5,
+  [41629] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -38807,7 +38942,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(715), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41640] = 5,
+  [41646] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(593), 1,
@@ -38819,7 +38954,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(729), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41657] = 5,
+  [41663] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(782), 1,
@@ -38831,7 +38966,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1157), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [41674] = 5,
+  [41680] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(587), 1,
@@ -38843,7 +38978,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(724), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41691] = 5,
+  [41697] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1161), 1,
@@ -38855,7 +38990,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1164), 2,
       anon_sym_RBRACE,
       anon_sym_DOT_DOT,
-  [41708] = 5,
+  [41714] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(766), 1,
@@ -38867,7 +39002,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(724), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41725] = 5,
+  [41731] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(599), 1,
@@ -38879,7 +39014,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(738), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41742] = 5,
+  [41748] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -38891,7 +39026,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(708), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41759] = 5,
+  [41765] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(611), 1,
@@ -38903,7 +39038,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(731), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41776] = 6,
+  [41782] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1085), 1,
@@ -38916,7 +39051,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_destruct,
     STATE(716), 1,
       sym_pattern,
-  [41795] = 5,
+  [41801] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(766), 1,
@@ -38928,7 +39063,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(729), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41812] = 5,
+  [41818] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(766), 1,
@@ -38940,7 +39075,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(730), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41829] = 5,
+  [41835] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(766), 1,
@@ -38952,7 +39087,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(731), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41846] = 5,
+  [41852] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -38964,7 +39099,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(694), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41863] = 3,
+  [41869] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1077), 2,
@@ -38974,7 +39109,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_end,
       sym_interpolation_start,
       sym_str_literal,
-  [41876] = 5,
+  [41882] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(605), 1,
@@ -38986,7 +39121,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(730), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41893] = 3,
+  [41899] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1115), 1,
@@ -38996,7 +39131,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [41906] = 3,
+  [41912] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1200), 2,
@@ -39006,7 +39141,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_end,
       sym_interpolation_start,
       sym_str_literal,
-  [41919] = 5,
+  [41925] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -39018,7 +39153,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(710), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41936] = 5,
+  [41942] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(766), 1,
@@ -39030,7 +39165,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(738), 2,
       sym_annot_atom,
       aux_sym_annot_repeat1,
-  [41953] = 3,
+  [41959] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1137), 1,
@@ -39040,7 +39175,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_double_quote,
       sym_mult_str_literal,
       sym_str_esc_char,
-  [41966] = 5,
+  [41972] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -39052,7 +39187,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(698), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [41983] = 3,
+  [41989] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1113), 2,
@@ -39062,7 +39197,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_end,
       sym_interpolation_start,
       sym_str_literal,
-  [41996] = 5,
+  [42002] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -39074,7 +39209,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(697), 2,
       sym_pattern,
       aux_sym_fun_expr_repeat1,
-  [42013] = 5,
+  [42019] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -39085,7 +39220,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_destruct,
     STATE(851), 1,
       sym_pattern,
-  [42029] = 2,
+  [42035] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(445), 4,
@@ -39093,7 +39228,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_PIPE_RBRACK,
-  [42039] = 5,
+  [42045] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39104,7 +39239,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(754), 1,
       aux_sym_type_atom_repeat1,
-  [42055] = 5,
+  [42061] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -39115,7 +39250,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_destruct,
     STATE(872), 1,
       sym_pattern,
-  [42071] = 5,
+  [42077] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39126,7 +39261,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(750), 1,
       aux_sym_type_atom_repeat1,
-  [42087] = 5,
+  [42093] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39137,7 +39272,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(760), 1,
       aux_sym_type_atom_repeat1,
-  [42103] = 5,
+  [42109] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39148,7 +39283,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(763), 1,
       aux_sym_type_atom_repeat1,
-  [42119] = 5,
+  [42125] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39159,7 +39294,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(754), 1,
       aux_sym_type_atom_repeat1,
-  [42135] = 2,
+  [42141] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(397), 4,
@@ -39167,7 +39302,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_PIPE_RBRACK,
-  [42145] = 5,
+  [42151] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39178,7 +39313,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(754), 1,
       aux_sym_type_atom_repeat1,
-  [42161] = 5,
+  [42167] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39189,7 +39324,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(755), 1,
       aux_sym_type_atom_repeat1,
-  [42177] = 4,
+  [42183] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1240), 1,
@@ -39199,7 +39334,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1243), 2,
       anon_sym_SEMI,
       anon_sym_PIPE_RBRACK,
-  [42191] = 5,
+  [42197] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39210,7 +39345,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(754), 1,
       aux_sym_type_atom_repeat1,
-  [42207] = 5,
+  [42213] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39221,7 +39356,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(745), 1,
       aux_sym_type_atom_repeat1,
-  [42223] = 3,
+  [42229] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1113), 2,
@@ -39230,7 +39365,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1115), 2,
       sym__str_end,
       sym_str_literal,
-  [42235] = 3,
+  [42241] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1200), 2,
@@ -39239,7 +39374,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1202), 2,
       sym__str_end,
       sym_str_literal,
-  [42247] = 3,
+  [42253] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1253), 1,
@@ -39248,7 +39383,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-  [42259] = 5,
+  [42265] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39259,7 +39394,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(754), 1,
       aux_sym_type_atom_repeat1,
-  [42275] = 5,
+  [42281] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -39270,7 +39405,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_destruct,
     STATE(712), 1,
       sym_pattern,
-  [42291] = 5,
+  [42297] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39281,7 +39416,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(752), 1,
       aux_sym_type_atom_repeat1,
-  [42307] = 5,
+  [42313] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1210), 1,
@@ -39292,7 +39427,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE_RBRACK,
     STATE(754), 1,
       aux_sym_type_atom_repeat1,
-  [42323] = 5,
+  [42329] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(907), 1,
@@ -39303,7 +39438,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_quoted_enum_tag,
     STATE(797), 1,
       sym_enum_tag,
-  [42339] = 5,
+  [42345] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -39314,7 +39449,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_destruct,
     STATE(864), 1,
       sym_pattern,
-  [42355] = 2,
+  [42361] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(377), 4,
@@ -39322,7 +39457,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_PIPE_RBRACK,
-  [42365] = 5,
+  [42371] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1081), 1,
@@ -39333,7 +39468,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_destruct,
     STATE(870), 1,
       sym_pattern,
-  [42381] = 4,
+  [42387] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1035), 1,
@@ -39342,7 +39477,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(840), 1,
       aux_sym_match_expr_repeat1,
-  [42394] = 4,
+  [42400] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1271), 1,
@@ -39351,7 +39486,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
     STATE(839), 1,
       aux_sym_atom_repeat1,
-  [42407] = 3,
+  [42413] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(904), 1,
@@ -39359,7 +39494,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42418] = 3,
+  [42424] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1277), 1,
@@ -39367,7 +39502,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1279), 2,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-  [42429] = 3,
+  [42435] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1281), 1,
@@ -39375,7 +39510,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1283), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [42440] = 4,
+  [42446] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1012), 1,
@@ -39384,7 +39519,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(840), 1,
       aux_sym_match_expr_repeat1,
-  [42453] = 3,
+  [42459] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(939), 1,
@@ -39392,7 +39527,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42464] = 3,
+  [42470] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(935), 1,
@@ -39400,7 +39535,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42475] = 3,
+  [42481] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(934), 1,
@@ -39408,7 +39543,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42486] = 3,
+  [42492] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(926), 1,
@@ -39416,7 +39551,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42497] = 3,
+  [42503] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(906), 1,
@@ -39424,7 +39559,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42508] = 3,
+  [42514] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(902), 1,
@@ -39432,7 +39567,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42519] = 3,
+  [42525] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(901), 1,
@@ -39440,28 +39575,28 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42530] = 2,
+  [42536] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(739), 3,
       sym_interpolation_end,
       anon_sym_PIPE,
       anon_sym_COLON,
-  [42539] = 2,
+  [42545] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(737), 3,
       sym_interpolation_end,
       anon_sym_PIPE,
       anon_sym_COLON,
-  [42548] = 2,
+  [42554] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(735), 3,
       sym_interpolation_end,
       anon_sym_PIPE,
       anon_sym_COLON,
-  [42557] = 4,
+  [42563] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1287), 1,
@@ -39470,7 +39605,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     STATE(560), 1,
       sym_static_string,
-  [42570] = 4,
+  [42576] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(143), 1,
@@ -39479,7 +39614,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(791), 1,
       aux_sym_atom_repeat1,
-  [42583] = 4,
+  [42589] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1293), 1,
@@ -39488,7 +39623,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     STATE(423), 1,
       sym_static_string,
-  [42596] = 3,
+  [42602] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(890), 1,
@@ -39496,7 +39631,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42607] = 3,
+  [42613] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(1007), 1,
@@ -39504,7 +39639,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42618] = 4,
+  [42624] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1297), 1,
@@ -39513,14 +39648,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     STATE(416), 1,
       sym_static_string,
-  [42631] = 2,
+  [42637] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(583), 3,
       sym_interpolation_end,
       anon_sym_PIPE,
       anon_sym_COLON,
-  [42640] = 4,
+  [42646] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1301), 1,
@@ -39529,21 +39664,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
     STATE(791), 1,
       aux_sym_atom_repeat1,
-  [42653] = 2,
+  [42659] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(754), 3,
       sym_interpolation_end,
       anon_sym_PIPE,
       anon_sym_COLON,
-  [42662] = 2,
+  [42668] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(752), 3,
       sym_interpolation_end,
       anon_sym_PIPE,
       anon_sym_COLON,
-  [42671] = 3,
+  [42677] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(945), 1,
@@ -39551,7 +39686,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42682] = 4,
+  [42688] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1306), 1,
@@ -39560,7 +39695,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(773), 1,
       aux_sym_match_expr_repeat1,
-  [42695] = 3,
+  [42701] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(911), 1,
@@ -39568,14 +39703,14 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42706] = 2,
+  [42712] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1243), 3,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_PIPE_RBRACK,
-  [42715] = 3,
+  [42721] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(960), 1,
@@ -39583,7 +39718,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42726] = 3,
+  [42732] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(908), 1,
@@ -39591,7 +39726,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42737] = 4,
+  [42743] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1310), 1,
@@ -39600,7 +39735,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOT,
     STATE(847), 1,
       aux_sym_forall_repeat1,
-  [42750] = 3,
+  [42756] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(1009), 1,
@@ -39608,7 +39743,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42761] = 4,
+  [42767] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1314), 1,
@@ -39617,7 +39752,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
     STATE(785), 1,
       aux_sym_atom_repeat1,
-  [42774] = 3,
+  [42780] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(1020), 1,
@@ -39625,7 +39760,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42785] = 3,
+  [42791] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(1023), 1,
@@ -39633,7 +39768,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42796] = 4,
+  [42802] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1318), 1,
@@ -39642,7 +39777,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
     STATE(818), 1,
       aux_sym_atom_repeat1,
-  [42809] = 3,
+  [42815] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(995), 1,
@@ -39650,7 +39785,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42820] = 3,
+  [42826] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(1013), 1,
@@ -39658,7 +39793,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42831] = 3,
+  [42837] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(990), 1,
@@ -39666,7 +39801,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42842] = 4,
+  [42848] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1310), 1,
@@ -39675,7 +39810,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOT,
     STATE(847), 1,
       aux_sym_forall_repeat1,
-  [42855] = 3,
+  [42861] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(988), 1,
@@ -39683,7 +39818,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42866] = 3,
+  [42872] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(887), 1,
@@ -39691,7 +39826,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [42877] = 4,
+  [42883] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1324), 1,
@@ -39700,7 +39835,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(830), 1,
       aux_sym_match_expr_repeat1,
-  [42890] = 4,
+  [42896] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1310), 1,
@@ -39709,14 +39844,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOT,
     STATE(847), 1,
       aux_sym_forall_repeat1,
-  [42903] = 2,
+  [42909] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1330), 3,
       anon_sym_EQ,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [42912] = 4,
+  [42918] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1332), 1,
@@ -39725,7 +39860,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
     STATE(825), 1,
       aux_sym_atom_repeat1,
-  [42925] = 3,
+  [42931] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1336), 1,
@@ -39733,14 +39868,14 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1338), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [42936] = 2,
+  [42942] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1164), 3,
       sym_ident,
       anon_sym_RBRACE,
       anon_sym_DOT_DOT,
-  [42945] = 4,
+  [42951] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(161), 1,
@@ -39749,7 +39884,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(791), 1,
       aux_sym_atom_repeat1,
-  [42958] = 4,
+  [42964] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(157), 1,
@@ -39758,14 +39893,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(791), 1,
       aux_sym_atom_repeat1,
-  [42971] = 2,
+  [42977] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(733), 3,
       sym_interpolation_end,
       anon_sym_PIPE,
       anon_sym_COLON,
-  [42980] = 4,
+  [42986] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1344), 1,
@@ -39774,7 +39909,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     STATE(140), 1,
       sym_static_string,
-  [42993] = 4,
+  [42999] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1348), 1,
@@ -39783,21 +39918,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(768), 1,
       aux_sym_match_expr_repeat1,
-  [43006] = 2,
+  [43012] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(525), 3,
       sym_interpolation_end,
       anon_sym_PIPE,
       anon_sym_COLON,
-  [43015] = 2,
+  [43021] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(501), 3,
       sym_interpolation_end,
       anon_sym_PIPE,
       anon_sym_COLON,
-  [43024] = 4,
+  [43030] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(147), 1,
@@ -39806,7 +39941,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(791), 1,
       aux_sym_atom_repeat1,
-  [43037] = 4,
+  [43043] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1354), 1,
@@ -39815,7 +39950,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
     STATE(819), 1,
       aux_sym_atom_repeat1,
-  [43050] = 4,
+  [43056] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1037), 1,
@@ -39824,7 +39959,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(840), 1,
       aux_sym_match_expr_repeat1,
-  [43063] = 4,
+  [43069] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1310), 1,
@@ -39833,7 +39968,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOT,
     STATE(847), 1,
       aux_sym_forall_repeat1,
-  [43076] = 4,
+  [43082] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1362), 1,
@@ -39842,7 +39977,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     STATE(434), 1,
       sym_static_string,
-  [43089] = 4,
+  [43095] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1039), 1,
@@ -39851,7 +39986,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(840), 1,
       aux_sym_match_expr_repeat1,
-  [43102] = 4,
+  [43108] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1368), 1,
@@ -39860,7 +39995,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(827), 1,
       aux_sym_match_expr_repeat1,
-  [43115] = 4,
+  [43121] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1372), 1,
@@ -39869,7 +40004,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     STATE(420), 1,
       sym_static_string,
-  [43128] = 4,
+  [43134] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1376), 1,
@@ -39878,7 +40013,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(846), 1,
       aux_sym_match_expr_repeat1,
-  [43141] = 4,
+  [43147] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1380), 1,
@@ -39887,7 +40022,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     STATE(782), 1,
       sym_static_string,
-  [43154] = 4,
+  [43160] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(165), 1,
@@ -39896,14 +40031,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(791), 1,
       aux_sym_atom_repeat1,
-  [43167] = 2,
+  [43173] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1386), 3,
       anon_sym_COMMA,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-  [43176] = 4,
+  [43182] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1388), 1,
@@ -39912,7 +40047,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(841), 1,
       aux_sym_match_expr_repeat1,
-  [43189] = 4,
+  [43195] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1310), 1,
@@ -39921,7 +40056,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOT,
     STATE(847), 1,
       aux_sym_forall_repeat1,
-  [43202] = 4,
+  [43208] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(153), 1,
@@ -39930,7 +40065,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(791), 1,
       aux_sym_atom_repeat1,
-  [43215] = 4,
+  [43221] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1396), 1,
@@ -39939,7 +40074,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(840), 1,
       aux_sym_match_expr_repeat1,
-  [43228] = 4,
+  [43234] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1061), 1,
@@ -39948,7 +40083,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(840), 1,
       aux_sym_match_expr_repeat1,
-  [43241] = 4,
+  [43247] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1310), 1,
@@ -39957,7 +40092,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOT,
     STATE(847), 1,
       aux_sym_forall_repeat1,
-  [43254] = 4,
+  [43260] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1405), 1,
@@ -39966,7 +40101,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
     STATE(835), 1,
       aux_sym_atom_repeat1,
-  [43267] = 3,
+  [43273] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(969), 1,
@@ -39974,7 +40109,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [43278] = 4,
+  [43284] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1409), 1,
@@ -39983,7 +40118,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__str_start,
     STATE(445), 1,
       sym_static_string,
-  [43291] = 4,
+  [43297] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1051), 1,
@@ -39992,7 +40127,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(840), 1,
       aux_sym_match_expr_repeat1,
-  [43304] = 4,
+  [43310] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1415), 1,
@@ -40001,14 +40136,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOT,
     STATE(847), 1,
       aux_sym_forall_repeat1,
-  [43317] = 2,
+  [43323] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1420), 3,
       anon_sym_COMMA,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-  [43326] = 3,
+  [43332] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(929), 1,
@@ -40016,1007 +40151,1007 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(1275), 2,
       sym_ident,
       anon_sym_Dyn,
-  [43337] = 3,
+  [43343] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1422), 1,
       sym_ident,
     STATE(809), 1,
       aux_sym_forall_repeat1,
-  [43347] = 2,
+  [43353] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1424), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [43355] = 3,
+  [43361] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1426), 1,
       anon_sym_RBRACE,
     ACTIONS(1428), 1,
       anon_sym_SEMI,
-  [43365] = 2,
+  [43371] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1279), 2,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-  [43373] = 3,
+  [43379] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1430), 1,
       sym_ident,
     STATE(828), 1,
       aux_sym_forall_repeat1,
-  [43383] = 3,
+  [43389] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1432), 1,
       sym_ident,
     STATE(813), 1,
       aux_sym_forall_repeat1,
-  [43393] = 3,
+  [43399] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1434), 1,
       anon_sym_RBRACE,
     ACTIONS(1436), 1,
       anon_sym_SEMI,
-  [43403] = 2,
+  [43409] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1304), 2,
       anon_sym_COMMA,
       anon_sym_RBRACK,
-  [43411] = 3,
+  [43417] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1438), 1,
       sym_ident,
     STATE(838), 1,
       aux_sym_forall_repeat1,
-  [43421] = 3,
+  [43427] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1440), 1,
       anon_sym_RBRACE,
     ACTIONS(1442), 1,
       anon_sym_SEMI,
-  [43431] = 2,
+  [43437] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1444), 2,
       anon_sym_default,
       anon_sym_force,
-  [43439] = 3,
+  [43445] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1446), 1,
       sym_ident,
     STATE(800), 1,
       aux_sym_forall_repeat1,
-  [43449] = 3,
+  [43455] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(657), 1,
       anon_sym_RPAREN,
     ACTIONS(1448), 1,
       sym_ident,
-  [43459] = 3,
+  [43465] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1450), 1,
       anon_sym_RBRACE,
     ACTIONS(1452), 1,
       anon_sym_SEMI,
-  [43469] = 2,
+  [43475] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1454), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [43477] = 2,
+  [43483] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1456), 2,
       anon_sym_default,
       anon_sym_force,
-  [43485] = 3,
+  [43491] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1458), 1,
       sym_ident,
     STATE(842), 1,
       aux_sym_forall_repeat1,
-  [43495] = 3,
+  [43501] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1460), 1,
       anon_sym_RBRACE,
     ACTIONS(1462), 1,
       anon_sym_SEMI,
-  [43505] = 3,
+  [43511] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1464), 1,
       anon_sym_RBRACE,
     ACTIONS(1466), 1,
       anon_sym_SEMI,
-  [43515] = 3,
+  [43521] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1468), 1,
       anon_sym_RBRACE,
     ACTIONS(1470), 1,
       anon_sym_SEMI,
-  [43525] = 2,
+  [43531] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1472), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [43533] = 3,
+  [43539] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1474), 1,
       anon_sym_RBRACE,
     ACTIONS(1476), 1,
       anon_sym_SEMI,
-  [43543] = 2,
+  [43549] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1478), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [43551] = 3,
+  [43557] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1085), 1,
       anon_sym_LBRACE,
     STATE(611), 1,
       sym_destruct,
-  [43561] = 3,
+  [43567] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1480), 1,
       anon_sym_RBRACE,
     ACTIONS(1482), 1,
       anon_sym_SEMI,
-  [43571] = 3,
+  [43577] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1484), 1,
       anon_sym_RBRACE,
     ACTIONS(1486), 1,
       anon_sym_SEMI,
-  [43581] = 3,
+  [43587] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1488), 1,
       anon_sym_COMMA,
     ACTIONS(1490), 1,
       anon_sym_RBRACE,
-  [43591] = 3,
+  [43597] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1492), 1,
       anon_sym_RBRACE,
     ACTIONS(1494), 1,
       anon_sym_SEMI,
-  [43601] = 2,
+  [43607] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1399), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [43609] = 3,
+  [43615] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1496), 1,
       anon_sym_RBRACE,
     ACTIONS(1498), 1,
       anon_sym_SEMI,
-  [43619] = 2,
+  [43625] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1500), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [43627] = 2,
+  [43633] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1502), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [43635] = 3,
+  [43641] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1490), 1,
       anon_sym_RBRACE,
     ACTIONS(1504), 1,
       sym_ident,
-  [43645] = 2,
+  [43651] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1506), 1,
       anon_sym_RPAREN,
-  [43652] = 2,
+  [43658] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(645), 1,
       anon_sym_RPAREN,
-  [43659] = 2,
+  [43665] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1407), 1,
       anon_sym_RBRACK,
-  [43666] = 2,
+  [43672] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1508), 1,
       anon_sym_PERCENT,
-  [43673] = 2,
+  [43679] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1510), 1,
       anon_sym_RBRACE,
-  [43680] = 2,
+  [43686] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1378), 1,
       anon_sym_RBRACE,
-  [43687] = 2,
+  [43693] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1390), 1,
       anon_sym_RBRACE,
-  [43694] = 2,
+  [43700] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1512), 1,
       anon_sym_RBRACE,
-  [43701] = 2,
+  [43707] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1514), 1,
       sym_interpolation_end,
-  [43708] = 2,
+  [43714] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(549), 1,
       sym_interpolation_end,
-  [43715] = 2,
+  [43721] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1516), 1,
       anon_sym_PIPE_RBRACK,
-  [43722] = 2,
+  [43728] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1518), 1,
       anon_sym_PERCENT,
-  [43729] = 2,
+  [43735] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(784), 1,
       sym_interpolation_end,
-  [43736] = 2,
+  [43742] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1273), 1,
       anon_sym_RBRACK,
-  [43743] = 2,
+  [43749] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1520), 1,
       anon_sym_in,
-  [43750] = 2,
+  [43756] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1522), 1,
       anon_sym_PIPE_RBRACK,
-  [43757] = 2,
+  [43763] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1524), 1,
       anon_sym_RPAREN,
-  [43764] = 2,
+  [43770] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1526), 1,
       anon_sym_RBRACE,
-  [43771] = 2,
+  [43777] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1528), 1,
       anon_sym_RBRACE,
-  [43778] = 2,
+  [43784] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1530), 1,
       anon_sym_RBRACE,
-  [43785] = 2,
+  [43791] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1532), 1,
       anon_sym_else,
-  [43792] = 2,
+  [43798] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1534), 1,
       anon_sym_RBRACE,
-  [43799] = 2,
+  [43805] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1536), 1,
       anon_sym_PIPE_RBRACK,
-  [43806] = 2,
+  [43812] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1538), 1,
       anon_sym_RBRACE,
-  [43813] = 2,
+  [43819] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1540), 1,
       anon_sym_PIPE_RBRACK,
-  [43820] = 2,
+  [43826] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1542), 1,
       anon_sym_RBRACE,
-  [43827] = 2,
+  [43833] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1544), 1,
       anon_sym_RBRACE,
-  [43834] = 2,
+  [43840] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1546), 1,
       anon_sym_RBRACE,
-  [43841] = 2,
+  [43847] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1548), 1,
       anon_sym_RBRACE,
-  [43848] = 2,
+  [43854] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1550), 1,
       anon_sym_RBRACE,
-  [43855] = 2,
+  [43861] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1552), 1,
       anon_sym_EQ_GT,
-  [43862] = 2,
+  [43868] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1554), 1,
       anon_sym_in,
-  [43869] = 2,
+  [43875] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1556), 1,
       anon_sym_PIPE_RBRACK,
-  [43876] = 2,
+  [43882] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(657), 1,
       anon_sym_RPAREN,
-  [43883] = 2,
+  [43889] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1370), 1,
       anon_sym_RBRACE,
-  [43890] = 2,
+  [43896] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1558), 1,
       anon_sym_RPAREN,
-  [43897] = 2,
+  [43903] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1356), 1,
       anon_sym_RBRACK,
-  [43904] = 2,
+  [43910] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1560), 1,
       anon_sym_EQ,
-  [43911] = 2,
+  [43917] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1562), 1,
       anon_sym_PERCENT,
-  [43918] = 2,
+  [43924] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(823), 1,
       sym_interpolation_end,
-  [43925] = 2,
+  [43931] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1564), 1,
       anon_sym_in,
-  [43932] = 2,
+  [43938] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1350), 1,
       anon_sym_RBRACE,
-  [43939] = 2,
+  [43945] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1566), 1,
       anon_sym_PIPE_RBRACK,
-  [43946] = 2,
+  [43952] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1568), 1,
       anon_sym_RBRACE,
-  [43953] = 2,
+  [43959] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1570), 1,
       anon_sym_EQ,
-  [43960] = 2,
+  [43966] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1572), 1,
       anon_sym_RBRACE,
-  [43967] = 2,
+  [43973] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1574), 1,
       anon_sym_RBRACE,
-  [43974] = 2,
+  [43980] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1576), 1,
       sym_ident,
-  [43981] = 2,
+  [43987] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1578), 1,
       anon_sym_PIPE_RBRACK,
-  [43988] = 2,
+  [43994] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1580), 1,
       anon_sym_RBRACE,
-  [43995] = 2,
+  [44001] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1582), 1,
       anon_sym_RBRACE,
-  [44002] = 2,
+  [44008] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1584), 1,
       anon_sym_RBRACE,
-  [44009] = 2,
+  [44015] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1586), 1,
       anon_sym_RBRACE,
-  [44016] = 2,
+  [44022] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1588), 1,
       anon_sym_else,
-  [44023] = 2,
+  [44029] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1590), 1,
       anon_sym_PIPE_RBRACK,
-  [44030] = 2,
+  [44036] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1592), 1,
       sym_ident,
-  [44037] = 2,
+  [44043] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1594), 1,
       anon_sym_RBRACE,
-  [44044] = 2,
+  [44050] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1596), 1,
       anon_sym_PIPE_RBRACK,
-  [44051] = 2,
+  [44057] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1598), 1,
       anon_sym_PERCENT,
-  [44058] = 2,
+  [44064] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1600), 1,
       anon_sym_PIPE_RBRACK,
-  [44065] = 2,
+  [44071] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1602), 1,
       sym_signed_num_literal,
-  [44072] = 2,
+  [44078] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1334), 1,
       anon_sym_RBRACK,
-  [44079] = 2,
+  [44085] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1604), 1,
       anon_sym_RBRACE,
-  [44086] = 2,
+  [44092] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1606), 1,
       sym_interpolation_end,
-  [44093] = 2,
+  [44099] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1608), 1,
       anon_sym_then,
-  [44100] = 2,
+  [44106] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1610), 1,
       anon_sym_else,
-  [44107] = 2,
+  [44113] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(661), 1,
       anon_sym_RPAREN,
-  [44114] = 2,
+  [44120] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1612), 1,
       anon_sym_RPAREN,
-  [44121] = 2,
+  [44127] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(529), 1,
       anon_sym_RPAREN,
-  [44128] = 2,
+  [44134] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(531), 1,
       anon_sym_RPAREN,
-  [44135] = 2,
+  [44141] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(635), 1,
       anon_sym_RPAREN,
-  [44142] = 2,
+  [44148] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(641), 1,
       anon_sym_RPAREN,
-  [44149] = 2,
+  [44155] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1614), 1,
       anon_sym_LBRACE,
-  [44156] = 2,
+  [44162] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1616), 1,
       anon_sym_PIPE_RBRACK,
-  [44163] = 2,
+  [44169] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1618), 1,
       sym_signed_num_literal,
-  [44170] = 2,
+  [44176] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1620), 1,
       sym_ident,
-  [44177] = 2,
+  [44183] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1622), 1,
       anon_sym_in,
-  [44184] = 2,
+  [44190] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1624), 1,
       anon_sym_RBRACE,
-  [44191] = 2,
+  [44197] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1626), 1,
       sym_ident,
-  [44198] = 2,
+  [44204] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1628), 1,
       anon_sym_RPAREN,
-  [44205] = 2,
+  [44211] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1326), 1,
       anon_sym_RBRACE,
-  [44212] = 2,
+  [44218] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1630), 1,
       anon_sym_RPAREN,
-  [44219] = 2,
+  [44225] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1632), 1,
       sym_ident,
-  [44226] = 2,
+  [44232] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1634), 1,
       sym_ident,
-  [44233] = 2,
+  [44239] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1636), 1,
       anon_sym_RPAREN,
-  [44240] = 2,
+  [44246] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1638), 1,
       sym_ident,
-  [44247] = 2,
+  [44253] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1640), 1,
       anon_sym_RBRACE,
-  [44254] = 2,
+  [44260] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1642), 1,
       anon_sym_LBRACE,
-  [44261] = 2,
+  [44267] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1644), 1,
       anon_sym_PIPE_RBRACK,
-  [44268] = 2,
+  [44274] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1646), 1,
       ts_builtin_sym_end,
-  [44275] = 2,
+  [44281] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1448), 1,
       sym_ident,
-  [44282] = 2,
+  [44288] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1316), 1,
       anon_sym_RBRACK,
-  [44289] = 2,
+  [44295] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1648), 1,
       sym_ident,
-  [44296] = 2,
+  [44302] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(649), 1,
       anon_sym_RPAREN,
-  [44303] = 2,
+  [44309] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1650), 1,
       anon_sym_PERCENT,
-  [44310] = 2,
+  [44316] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1320), 1,
       anon_sym_RBRACK,
-  [44317] = 2,
+  [44323] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1652), 1,
       anon_sym_PIPE_RBRACK,
-  [44324] = 2,
+  [44330] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1654), 1,
       sym_ident,
-  [44331] = 2,
+  [44337] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1656), 1,
       anon_sym_RPAREN,
-  [44338] = 2,
+  [44344] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1658), 1,
       sym_ident,
-  [44345] = 2,
+  [44351] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1660), 1,
       anon_sym_PERCENT,
-  [44352] = 2,
+  [44358] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1662), 1,
       anon_sym_LBRACE,
-  [44359] = 2,
+  [44365] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1664), 1,
       anon_sym_RBRACE,
-  [44366] = 2,
+  [44372] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1666), 1,
       sym_ident,
-  [44373] = 2,
+  [44379] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1668), 1,
       sym_ident,
-  [44380] = 2,
+  [44386] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1670), 1,
       anon_sym_RBRACE,
-  [44387] = 2,
+  [44393] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1672), 1,
       sym_ident,
-  [44394] = 2,
+  [44400] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1674), 1,
       anon_sym_RBRACE,
-  [44401] = 2,
+  [44407] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1676), 1,
       anon_sym_EQ_GT,
-  [44408] = 2,
+  [44414] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1308), 1,
       anon_sym_RBRACE,
-  [44415] = 2,
+  [44421] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1678), 1,
       anon_sym_RBRACE,
-  [44422] = 2,
+  [44428] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1680), 1,
       sym_ident,
-  [44429] = 2,
+  [44435] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1682), 1,
       anon_sym_RBRACE,
-  [44436] = 2,
+  [44442] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1684), 1,
       sym_ident,
-  [44443] = 2,
+  [44449] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(653), 1,
       anon_sym_RPAREN,
-  [44450] = 2,
+  [44456] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1686), 1,
       anon_sym_LBRACE,
-  [44457] = 2,
+  [44463] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1688), 1,
       anon_sym_else,
-  [44464] = 2,
+  [44470] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1690), 1,
       anon_sym_PIPE_RBRACK,
-  [44471] = 2,
+  [44477] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1692), 1,
       sym_ident,
-  [44478] = 2,
+  [44484] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1488), 1,
       anon_sym_COMMA,
-  [44485] = 2,
+  [44491] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1694), 1,
       sym_ident,
-  [44492] = 2,
+  [44498] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1696), 1,
       anon_sym_PIPE_RBRACK,
-  [44499] = 2,
+  [44505] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(821), 1,
       sym_interpolation_end,
-  [44506] = 2,
+  [44512] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1698), 1,
       anon_sym_PIPE_RBRACK,
-  [44513] = 2,
+  [44519] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1700), 1,
       anon_sym_RBRACE,
-  [44520] = 2,
+  [44526] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1702), 1,
       sym_ident,
-  [44527] = 2,
+  [44533] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1704), 1,
       anon_sym_RBRACE,
-  [44534] = 2,
+  [44540] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1706), 1,
       sym_ident,
-  [44541] = 2,
+  [44547] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1708), 1,
       anon_sym_RPAREN,
-  [44548] = 2,
+  [44554] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1710), 1,
       anon_sym_LBRACE,
-  [44555] = 2,
+  [44561] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1712), 1,
       anon_sym_RBRACE,
-  [44562] = 2,
+  [44568] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1714), 1,
       anon_sym_PIPE_RBRACK,
-  [44569] = 2,
+  [44575] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1716), 1,
       sym_ident,
-  [44576] = 2,
+  [44582] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1718), 1,
       anon_sym_PIPE_RBRACK,
-  [44583] = 2,
+  [44589] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1720), 1,
       sym_ident,
-  [44590] = 2,
+  [44596] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1722), 1,
       anon_sym_LBRACE,
-  [44597] = 2,
+  [44603] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1724), 1,
       anon_sym_else,
-  [44604] = 2,
+  [44610] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1726), 1,
       anon_sym_RBRACE,
-  [44611] = 2,
+  [44617] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1728), 1,
       anon_sym_COLON,
-  [44618] = 2,
+  [44624] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1730), 1,
       sym_ident,
-  [44625] = 2,
+  [44631] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1732), 1,
       anon_sym_RBRACE,
-  [44632] = 2,
+  [44638] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1734), 1,
       sym_ident,
-  [44639] = 2,
+  [44645] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1736), 1,
       anon_sym_COLON,
-  [44646] = 2,
+  [44652] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1738), 1,
       anon_sym_then,
-  [44653] = 2,
+  [44659] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1740), 1,
       anon_sym_COLON,
-  [44660] = 2,
+  [44666] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1742), 1,
       anon_sym_then,
-  [44667] = 2,
+  [44673] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1744), 1,
       anon_sym_COLON,
-  [44674] = 2,
+  [44680] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1746), 1,
       anon_sym_then,
-  [44681] = 2,
+  [44687] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1748), 1,
       anon_sym_COLON,
-  [44688] = 2,
+  [44694] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1750), 1,
       anon_sym_then,
-  [44695] = 2,
+  [44701] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1752), 1,
       anon_sym_COLON,
-  [44702] = 2,
+  [44708] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1754), 1,
       anon_sym_then,
-  [44709] = 2,
+  [44715] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1756), 1,
       anon_sym_RBRACE,
-  [44716] = 2,
+  [44722] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1758), 1,
       anon_sym_else,
-  [44723] = 2,
+  [44729] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(1277), 1,
       anon_sym_COMMA,
-  [44730] = 2,
+  [44736] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(817), 1,
       sym_interpolation_end,
-  [44737] = 2,
+  [44743] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(792), 1,
@@ -41086,976 +41221,976 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(67)] = 7655,
   [SMALL_STATE(68)] = 7784,
   [SMALL_STATE(69)] = 7913,
-  [SMALL_STATE(70)] = 8008,
-  [SMALL_STATE(71)] = 8103,
-  [SMALL_STATE(72)] = 8198,
-  [SMALL_STATE(73)] = 8293,
-  [SMALL_STATE(74)] = 8388,
-  [SMALL_STATE(75)] = 8512,
-  [SMALL_STATE(76)] = 8636,
-  [SMALL_STATE(77)] = 8760,
-  [SMALL_STATE(78)] = 8884,
-  [SMALL_STATE(79)] = 9008,
-  [SMALL_STATE(80)] = 9132,
-  [SMALL_STATE(81)] = 9185,
-  [SMALL_STATE(82)] = 9238,
-  [SMALL_STATE(83)] = 9291,
-  [SMALL_STATE(84)] = 9344,
-  [SMALL_STATE(85)] = 9399,
-  [SMALL_STATE(86)] = 9452,
-  [SMALL_STATE(87)] = 9505,
-  [SMALL_STATE(88)] = 9558,
-  [SMALL_STATE(89)] = 9611,
-  [SMALL_STATE(90)] = 9664,
-  [SMALL_STATE(91)] = 9717,
-  [SMALL_STATE(92)] = 9770,
-  [SMALL_STATE(93)] = 9823,
-  [SMALL_STATE(94)] = 9876,
-  [SMALL_STATE(95)] = 9929,
-  [SMALL_STATE(96)] = 9982,
-  [SMALL_STATE(97)] = 10035,
-  [SMALL_STATE(98)] = 10088,
-  [SMALL_STATE(99)] = 10143,
-  [SMALL_STATE(100)] = 10196,
-  [SMALL_STATE(101)] = 10249,
-  [SMALL_STATE(102)] = 10304,
-  [SMALL_STATE(103)] = 10357,
-  [SMALL_STATE(104)] = 10410,
-  [SMALL_STATE(105)] = 10463,
-  [SMALL_STATE(106)] = 10516,
-  [SMALL_STATE(107)] = 10569,
-  [SMALL_STATE(108)] = 10622,
-  [SMALL_STATE(109)] = 10675,
-  [SMALL_STATE(110)] = 10728,
-  [SMALL_STATE(111)] = 10781,
-  [SMALL_STATE(112)] = 10834,
-  [SMALL_STATE(113)] = 10887,
-  [SMALL_STATE(114)] = 10940,
-  [SMALL_STATE(115)] = 10993,
-  [SMALL_STATE(116)] = 11046,
-  [SMALL_STATE(117)] = 11099,
-  [SMALL_STATE(118)] = 11152,
-  [SMALL_STATE(119)] = 11205,
-  [SMALL_STATE(120)] = 11257,
-  [SMALL_STATE(121)] = 11309,
-  [SMALL_STATE(122)] = 11419,
-  [SMALL_STATE(123)] = 11529,
-  [SMALL_STATE(124)] = 11639,
-  [SMALL_STATE(125)] = 11749,
-  [SMALL_STATE(126)] = 11859,
-  [SMALL_STATE(127)] = 11969,
-  [SMALL_STATE(128)] = 12021,
-  [SMALL_STATE(129)] = 12131,
-  [SMALL_STATE(130)] = 12241,
-  [SMALL_STATE(131)] = 12351,
-  [SMALL_STATE(132)] = 12403,
-  [SMALL_STATE(133)] = 12513,
-  [SMALL_STATE(134)] = 12565,
-  [SMALL_STATE(135)] = 12675,
-  [SMALL_STATE(136)] = 12785,
-  [SMALL_STATE(137)] = 12895,
-  [SMALL_STATE(138)] = 12947,
-  [SMALL_STATE(139)] = 13057,
-  [SMALL_STATE(140)] = 13167,
-  [SMALL_STATE(141)] = 13219,
-  [SMALL_STATE(142)] = 13329,
-  [SMALL_STATE(143)] = 13439,
-  [SMALL_STATE(144)] = 13491,
-  [SMALL_STATE(145)] = 13601,
-  [SMALL_STATE(146)] = 13705,
-  [SMALL_STATE(147)] = 13809,
-  [SMALL_STATE(148)] = 13910,
-  [SMALL_STATE(149)] = 14011,
-  [SMALL_STATE(150)] = 14112,
-  [SMALL_STATE(151)] = 14213,
-  [SMALL_STATE(152)] = 14314,
-  [SMALL_STATE(153)] = 14415,
-  [SMALL_STATE(154)] = 14516,
-  [SMALL_STATE(155)] = 14617,
-  [SMALL_STATE(156)] = 14718,
-  [SMALL_STATE(157)] = 14819,
-  [SMALL_STATE(158)] = 14920,
-  [SMALL_STATE(159)] = 15021,
-  [SMALL_STATE(160)] = 15122,
-  [SMALL_STATE(161)] = 15223,
-  [SMALL_STATE(162)] = 15324,
-  [SMALL_STATE(163)] = 15425,
-  [SMALL_STATE(164)] = 15526,
-  [SMALL_STATE(165)] = 15627,
-  [SMALL_STATE(166)] = 15728,
-  [SMALL_STATE(167)] = 15829,
-  [SMALL_STATE(168)] = 15930,
-  [SMALL_STATE(169)] = 16031,
-  [SMALL_STATE(170)] = 16132,
-  [SMALL_STATE(171)] = 16233,
-  [SMALL_STATE(172)] = 16334,
-  [SMALL_STATE(173)] = 16435,
-  [SMALL_STATE(174)] = 16536,
-  [SMALL_STATE(175)] = 16637,
-  [SMALL_STATE(176)] = 16738,
-  [SMALL_STATE(177)] = 16839,
-  [SMALL_STATE(178)] = 16940,
-  [SMALL_STATE(179)] = 17041,
-  [SMALL_STATE(180)] = 17142,
-  [SMALL_STATE(181)] = 17243,
-  [SMALL_STATE(182)] = 17344,
-  [SMALL_STATE(183)] = 17445,
-  [SMALL_STATE(184)] = 17546,
-  [SMALL_STATE(185)] = 17647,
-  [SMALL_STATE(186)] = 17748,
-  [SMALL_STATE(187)] = 17849,
-  [SMALL_STATE(188)] = 17950,
-  [SMALL_STATE(189)] = 18051,
-  [SMALL_STATE(190)] = 18152,
-  [SMALL_STATE(191)] = 18253,
-  [SMALL_STATE(192)] = 18354,
-  [SMALL_STATE(193)] = 18455,
-  [SMALL_STATE(194)] = 18556,
-  [SMALL_STATE(195)] = 18657,
-  [SMALL_STATE(196)] = 18758,
-  [SMALL_STATE(197)] = 18859,
-  [SMALL_STATE(198)] = 18960,
-  [SMALL_STATE(199)] = 19061,
-  [SMALL_STATE(200)] = 19162,
-  [SMALL_STATE(201)] = 19263,
-  [SMALL_STATE(202)] = 19364,
-  [SMALL_STATE(203)] = 19465,
-  [SMALL_STATE(204)] = 19566,
-  [SMALL_STATE(205)] = 19667,
-  [SMALL_STATE(206)] = 19768,
-  [SMALL_STATE(207)] = 19869,
-  [SMALL_STATE(208)] = 19970,
-  [SMALL_STATE(209)] = 20071,
-  [SMALL_STATE(210)] = 20172,
-  [SMALL_STATE(211)] = 20273,
-  [SMALL_STATE(212)] = 20374,
-  [SMALL_STATE(213)] = 20475,
-  [SMALL_STATE(214)] = 20522,
-  [SMALL_STATE(215)] = 20569,
-  [SMALL_STATE(216)] = 20616,
-  [SMALL_STATE(217)] = 20663,
-  [SMALL_STATE(218)] = 20710,
-  [SMALL_STATE(219)] = 20757,
-  [SMALL_STATE(220)] = 20804,
-  [SMALL_STATE(221)] = 20851,
-  [SMALL_STATE(222)] = 20898,
-  [SMALL_STATE(223)] = 20945,
-  [SMALL_STATE(224)] = 20992,
-  [SMALL_STATE(225)] = 21039,
-  [SMALL_STATE(226)] = 21086,
-  [SMALL_STATE(227)] = 21133,
-  [SMALL_STATE(228)] = 21180,
-  [SMALL_STATE(229)] = 21227,
-  [SMALL_STATE(230)] = 21274,
-  [SMALL_STATE(231)] = 21321,
-  [SMALL_STATE(232)] = 21370,
-  [SMALL_STATE(233)] = 21417,
-  [SMALL_STATE(234)] = 21464,
-  [SMALL_STATE(235)] = 21511,
-  [SMALL_STATE(236)] = 21560,
-  [SMALL_STATE(237)] = 21607,
-  [SMALL_STATE(238)] = 21654,
-  [SMALL_STATE(239)] = 21701,
-  [SMALL_STATE(240)] = 21748,
-  [SMALL_STATE(241)] = 21795,
-  [SMALL_STATE(242)] = 21842,
-  [SMALL_STATE(243)] = 21891,
-  [SMALL_STATE(244)] = 21938,
-  [SMALL_STATE(245)] = 21985,
-  [SMALL_STATE(246)] = 22034,
-  [SMALL_STATE(247)] = 22081,
-  [SMALL_STATE(248)] = 22128,
-  [SMALL_STATE(249)] = 22175,
-  [SMALL_STATE(250)] = 22222,
-  [SMALL_STATE(251)] = 22269,
-  [SMALL_STATE(252)] = 22316,
-  [SMALL_STATE(253)] = 22363,
-  [SMALL_STATE(254)] = 22410,
-  [SMALL_STATE(255)] = 22457,
-  [SMALL_STATE(256)] = 22504,
-  [SMALL_STATE(257)] = 22551,
-  [SMALL_STATE(258)] = 22598,
-  [SMALL_STATE(259)] = 22645,
-  [SMALL_STATE(260)] = 22692,
-  [SMALL_STATE(261)] = 22739,
-  [SMALL_STATE(262)] = 22786,
-  [SMALL_STATE(263)] = 22835,
-  [SMALL_STATE(264)] = 22882,
-  [SMALL_STATE(265)] = 22929,
-  [SMALL_STATE(266)] = 22976,
-  [SMALL_STATE(267)] = 23025,
-  [SMALL_STATE(268)] = 23072,
-  [SMALL_STATE(269)] = 23119,
-  [SMALL_STATE(270)] = 23166,
-  [SMALL_STATE(271)] = 23213,
-  [SMALL_STATE(272)] = 23262,
-  [SMALL_STATE(273)] = 23309,
-  [SMALL_STATE(274)] = 23356,
-  [SMALL_STATE(275)] = 23403,
-  [SMALL_STATE(276)] = 23450,
-  [SMALL_STATE(277)] = 23497,
-  [SMALL_STATE(278)] = 23544,
-  [SMALL_STATE(279)] = 23591,
-  [SMALL_STATE(280)] = 23638,
-  [SMALL_STATE(281)] = 23685,
-  [SMALL_STATE(282)] = 23732,
-  [SMALL_STATE(283)] = 23779,
-  [SMALL_STATE(284)] = 23828,
-  [SMALL_STATE(285)] = 23875,
-  [SMALL_STATE(286)] = 23922,
-  [SMALL_STATE(287)] = 23969,
-  [SMALL_STATE(288)] = 24016,
-  [SMALL_STATE(289)] = 24063,
-  [SMALL_STATE(290)] = 24110,
-  [SMALL_STATE(291)] = 24157,
-  [SMALL_STATE(292)] = 24204,
-  [SMALL_STATE(293)] = 24251,
-  [SMALL_STATE(294)] = 24298,
-  [SMALL_STATE(295)] = 24345,
-  [SMALL_STATE(296)] = 24392,
-  [SMALL_STATE(297)] = 24439,
-  [SMALL_STATE(298)] = 24488,
-  [SMALL_STATE(299)] = 24535,
-  [SMALL_STATE(300)] = 24582,
-  [SMALL_STATE(301)] = 24629,
-  [SMALL_STATE(302)] = 24676,
-  [SMALL_STATE(303)] = 24723,
-  [SMALL_STATE(304)] = 24770,
-  [SMALL_STATE(305)] = 24817,
-  [SMALL_STATE(306)] = 24864,
-  [SMALL_STATE(307)] = 24911,
-  [SMALL_STATE(308)] = 24958,
-  [SMALL_STATE(309)] = 25005,
-  [SMALL_STATE(310)] = 25052,
-  [SMALL_STATE(311)] = 25101,
-  [SMALL_STATE(312)] = 25148,
-  [SMALL_STATE(313)] = 25195,
-  [SMALL_STATE(314)] = 25242,
-  [SMALL_STATE(315)] = 25289,
-  [SMALL_STATE(316)] = 25336,
-  [SMALL_STATE(317)] = 25383,
-  [SMALL_STATE(318)] = 25430,
-  [SMALL_STATE(319)] = 25477,
-  [SMALL_STATE(320)] = 25524,
-  [SMALL_STATE(321)] = 25571,
-  [SMALL_STATE(322)] = 25618,
-  [SMALL_STATE(323)] = 25665,
-  [SMALL_STATE(324)] = 25714,
-  [SMALL_STATE(325)] = 25761,
-  [SMALL_STATE(326)] = 25808,
-  [SMALL_STATE(327)] = 25857,
-  [SMALL_STATE(328)] = 25904,
-  [SMALL_STATE(329)] = 25951,
-  [SMALL_STATE(330)] = 25998,
-  [SMALL_STATE(331)] = 26045,
-  [SMALL_STATE(332)] = 26092,
-  [SMALL_STATE(333)] = 26139,
-  [SMALL_STATE(334)] = 26186,
-  [SMALL_STATE(335)] = 26233,
-  [SMALL_STATE(336)] = 26280,
-  [SMALL_STATE(337)] = 26327,
-  [SMALL_STATE(338)] = 26374,
-  [SMALL_STATE(339)] = 26421,
-  [SMALL_STATE(340)] = 26468,
-  [SMALL_STATE(341)] = 26515,
-  [SMALL_STATE(342)] = 26562,
-  [SMALL_STATE(343)] = 26611,
-  [SMALL_STATE(344)] = 26658,
-  [SMALL_STATE(345)] = 26705,
-  [SMALL_STATE(346)] = 26752,
-  [SMALL_STATE(347)] = 26799,
-  [SMALL_STATE(348)] = 26846,
-  [SMALL_STATE(349)] = 26893,
-  [SMALL_STATE(350)] = 26942,
-  [SMALL_STATE(351)] = 26991,
-  [SMALL_STATE(352)] = 27038,
-  [SMALL_STATE(353)] = 27085,
-  [SMALL_STATE(354)] = 27132,
-  [SMALL_STATE(355)] = 27179,
-  [SMALL_STATE(356)] = 27226,
-  [SMALL_STATE(357)] = 27273,
-  [SMALL_STATE(358)] = 27320,
-  [SMALL_STATE(359)] = 27367,
-  [SMALL_STATE(360)] = 27414,
-  [SMALL_STATE(361)] = 27461,
-  [SMALL_STATE(362)] = 27508,
-  [SMALL_STATE(363)] = 27555,
-  [SMALL_STATE(364)] = 27602,
-  [SMALL_STATE(365)] = 27649,
-  [SMALL_STATE(366)] = 27696,
-  [SMALL_STATE(367)] = 27743,
-  [SMALL_STATE(368)] = 27790,
-  [SMALL_STATE(369)] = 27837,
-  [SMALL_STATE(370)] = 27884,
-  [SMALL_STATE(371)] = 27931,
-  [SMALL_STATE(372)] = 27978,
-  [SMALL_STATE(373)] = 28025,
-  [SMALL_STATE(374)] = 28072,
-  [SMALL_STATE(375)] = 28119,
-  [SMALL_STATE(376)] = 28166,
-  [SMALL_STATE(377)] = 28213,
-  [SMALL_STATE(378)] = 28260,
-  [SMALL_STATE(379)] = 28307,
-  [SMALL_STATE(380)] = 28354,
-  [SMALL_STATE(381)] = 28401,
-  [SMALL_STATE(382)] = 28448,
-  [SMALL_STATE(383)] = 28495,
-  [SMALL_STATE(384)] = 28542,
-  [SMALL_STATE(385)] = 28589,
-  [SMALL_STATE(386)] = 28636,
-  [SMALL_STATE(387)] = 28683,
-  [SMALL_STATE(388)] = 28730,
-  [SMALL_STATE(389)] = 28777,
-  [SMALL_STATE(390)] = 28824,
-  [SMALL_STATE(391)] = 28871,
-  [SMALL_STATE(392)] = 28918,
-  [SMALL_STATE(393)] = 28965,
-  [SMALL_STATE(394)] = 29012,
-  [SMALL_STATE(395)] = 29059,
-  [SMALL_STATE(396)] = 29106,
-  [SMALL_STATE(397)] = 29153,
-  [SMALL_STATE(398)] = 29200,
-  [SMALL_STATE(399)] = 29247,
-  [SMALL_STATE(400)] = 29294,
-  [SMALL_STATE(401)] = 29341,
-  [SMALL_STATE(402)] = 29388,
-  [SMALL_STATE(403)] = 29435,
-  [SMALL_STATE(404)] = 29482,
-  [SMALL_STATE(405)] = 29529,
-  [SMALL_STATE(406)] = 29576,
-  [SMALL_STATE(407)] = 29623,
-  [SMALL_STATE(408)] = 29670,
-  [SMALL_STATE(409)] = 29716,
-  [SMALL_STATE(410)] = 29762,
-  [SMALL_STATE(411)] = 29808,
-  [SMALL_STATE(412)] = 29854,
-  [SMALL_STATE(413)] = 29900,
-  [SMALL_STATE(414)] = 29946,
-  [SMALL_STATE(415)] = 29992,
-  [SMALL_STATE(416)] = 30038,
-  [SMALL_STATE(417)] = 30084,
-  [SMALL_STATE(418)] = 30130,
-  [SMALL_STATE(419)] = 30176,
-  [SMALL_STATE(420)] = 30222,
-  [SMALL_STATE(421)] = 30268,
-  [SMALL_STATE(422)] = 30314,
-  [SMALL_STATE(423)] = 30360,
-  [SMALL_STATE(424)] = 30406,
-  [SMALL_STATE(425)] = 30452,
-  [SMALL_STATE(426)] = 30498,
-  [SMALL_STATE(427)] = 30544,
-  [SMALL_STATE(428)] = 30590,
-  [SMALL_STATE(429)] = 30636,
-  [SMALL_STATE(430)] = 30682,
-  [SMALL_STATE(431)] = 30728,
-  [SMALL_STATE(432)] = 30774,
-  [SMALL_STATE(433)] = 30820,
-  [SMALL_STATE(434)] = 30866,
-  [SMALL_STATE(435)] = 30912,
-  [SMALL_STATE(436)] = 30958,
-  [SMALL_STATE(437)] = 31004,
-  [SMALL_STATE(438)] = 31050,
-  [SMALL_STATE(439)] = 31096,
-  [SMALL_STATE(440)] = 31142,
-  [SMALL_STATE(441)] = 31188,
-  [SMALL_STATE(442)] = 31234,
-  [SMALL_STATE(443)] = 31280,
-  [SMALL_STATE(444)] = 31326,
-  [SMALL_STATE(445)] = 31372,
-  [SMALL_STATE(446)] = 31418,
-  [SMALL_STATE(447)] = 31464,
-  [SMALL_STATE(448)] = 31510,
-  [SMALL_STATE(449)] = 31601,
-  [SMALL_STATE(450)] = 31662,
-  [SMALL_STATE(451)] = 31735,
-  [SMALL_STATE(452)] = 31810,
-  [SMALL_STATE(453)] = 31875,
-  [SMALL_STATE(454)] = 31934,
-  [SMALL_STATE(455)] = 32015,
-  [SMALL_STATE(456)] = 32096,
-  [SMALL_STATE(457)] = 32165,
-  [SMALL_STATE(458)] = 32228,
-  [SMALL_STATE(459)] = 32293,
-  [SMALL_STATE(460)] = 32352,
-  [SMALL_STATE(461)] = 32429,
-  [SMALL_STATE(462)] = 32513,
-  [SMALL_STATE(463)] = 32597,
-  [SMALL_STATE(464)] = 32681,
-  [SMALL_STATE(465)] = 32765,
-  [SMALL_STATE(466)] = 32849,
-  [SMALL_STATE(467)] = 32922,
-  [SMALL_STATE(468)] = 32995,
-  [SMALL_STATE(469)] = 33068,
-  [SMALL_STATE(470)] = 33141,
-  [SMALL_STATE(471)] = 33214,
-  [SMALL_STATE(472)] = 33287,
-  [SMALL_STATE(473)] = 33346,
-  [SMALL_STATE(474)] = 33421,
-  [SMALL_STATE(475)] = 33492,
-  [SMALL_STATE(476)] = 33567,
-  [SMALL_STATE(477)] = 33636,
-  [SMALL_STATE(478)] = 33703,
-  [SMALL_STATE(479)] = 33774,
-  [SMALL_STATE(480)] = 33833,
-  [SMALL_STATE(481)] = 33908,
-  [SMALL_STATE(482)] = 33971,
-  [SMALL_STATE(483)] = 34040,
-  [SMALL_STATE(484)] = 34099,
-  [SMALL_STATE(485)] = 34166,
-  [SMALL_STATE(486)] = 34229,
-  [SMALL_STATE(487)] = 34282,
-  [SMALL_STATE(488)] = 34341,
-  [SMALL_STATE(489)] = 34416,
-  [SMALL_STATE(490)] = 34469,
-  [SMALL_STATE(491)] = 34524,
-  [SMALL_STATE(492)] = 34577,
-  [SMALL_STATE(493)] = 34634,
-  [SMALL_STATE(494)] = 34693,
-  [SMALL_STATE(495)] = 34752,
-  [SMALL_STATE(496)] = 34815,
-  [SMALL_STATE(497)] = 34882,
-  [SMALL_STATE(498)] = 34951,
-  [SMALL_STATE(499)] = 35022,
-  [SMALL_STATE(500)] = 35097,
-  [SMALL_STATE(501)] = 35172,
-  [SMALL_STATE(502)] = 35247,
-  [SMALL_STATE(503)] = 35304,
-  [SMALL_STATE(504)] = 35361,
-  [SMALL_STATE(505)] = 35416,
-  [SMALL_STATE(506)] = 35471,
-  [SMALL_STATE(507)] = 35524,
-  [SMALL_STATE(508)] = 35577,
-  [SMALL_STATE(509)] = 35636,
-  [SMALL_STATE(510)] = 35689,
-  [SMALL_STATE(511)] = 35764,
-  [SMALL_STATE(512)] = 35817,
-  [SMALL_STATE(513)] = 35870,
-  [SMALL_STATE(514)] = 35925,
-  [SMALL_STATE(515)] = 35982,
-  [SMALL_STATE(516)] = 36041,
-  [SMALL_STATE(517)] = 36104,
-  [SMALL_STATE(518)] = 36171,
-  [SMALL_STATE(519)] = 36240,
-  [SMALL_STATE(520)] = 36311,
-  [SMALL_STATE(521)] = 36370,
-  [SMALL_STATE(522)] = 36445,
-  [SMALL_STATE(523)] = 36520,
-  [SMALL_STATE(524)] = 36573,
-  [SMALL_STATE(525)] = 36626,
-  [SMALL_STATE(526)] = 36681,
-  [SMALL_STATE(527)] = 36752,
-  [SMALL_STATE(528)] = 36821,
-  [SMALL_STATE(529)] = 36888,
-  [SMALL_STATE(530)] = 36951,
-  [SMALL_STATE(531)] = 37010,
-  [SMALL_STATE(532)] = 37067,
-  [SMALL_STATE(533)] = 37102,
-  [SMALL_STATE(534)] = 37137,
-  [SMALL_STATE(535)] = 37172,
-  [SMALL_STATE(536)] = 37207,
-  [SMALL_STATE(537)] = 37239,
-  [SMALL_STATE(538)] = 37270,
-  [SMALL_STATE(539)] = 37301,
-  [SMALL_STATE(540)] = 37332,
-  [SMALL_STATE(541)] = 37363,
-  [SMALL_STATE(542)] = 37394,
-  [SMALL_STATE(543)] = 37425,
-  [SMALL_STATE(544)] = 37456,
-  [SMALL_STATE(545)] = 37487,
-  [SMALL_STATE(546)] = 37534,
-  [SMALL_STATE(547)] = 37581,
-  [SMALL_STATE(548)] = 37628,
-  [SMALL_STATE(549)] = 37675,
-  [SMALL_STATE(550)] = 37722,
-  [SMALL_STATE(551)] = 37769,
-  [SMALL_STATE(552)] = 37813,
-  [SMALL_STATE(553)] = 37857,
-  [SMALL_STATE(554)] = 37901,
-  [SMALL_STATE(555)] = 37945,
-  [SMALL_STATE(556)] = 37989,
-  [SMALL_STATE(557)] = 38033,
-  [SMALL_STATE(558)] = 38052,
-  [SMALL_STATE(559)] = 38071,
-  [SMALL_STATE(560)] = 38090,
-  [SMALL_STATE(561)] = 38109,
-  [SMALL_STATE(562)] = 38128,
-  [SMALL_STATE(563)] = 38147,
-  [SMALL_STATE(564)] = 38184,
-  [SMALL_STATE(565)] = 38203,
-  [SMALL_STATE(566)] = 38222,
-  [SMALL_STATE(567)] = 38241,
-  [SMALL_STATE(568)] = 38264,
-  [SMALL_STATE(569)] = 38287,
-  [SMALL_STATE(570)] = 38313,
-  [SMALL_STATE(571)] = 38339,
-  [SMALL_STATE(572)] = 38369,
-  [SMALL_STATE(573)] = 38385,
-  [SMALL_STATE(574)] = 38411,
-  [SMALL_STATE(575)] = 38427,
-  [SMALL_STATE(576)] = 38453,
-  [SMALL_STATE(577)] = 38479,
-  [SMALL_STATE(578)] = 38495,
-  [SMALL_STATE(579)] = 38521,
-  [SMALL_STATE(580)] = 38547,
-  [SMALL_STATE(581)] = 38573,
-  [SMALL_STATE(582)] = 38599,
-  [SMALL_STATE(583)] = 38625,
-  [SMALL_STATE(584)] = 38651,
-  [SMALL_STATE(585)] = 38677,
-  [SMALL_STATE(586)] = 38693,
-  [SMALL_STATE(587)] = 38719,
-  [SMALL_STATE(588)] = 38735,
-  [SMALL_STATE(589)] = 38751,
-  [SMALL_STATE(590)] = 38777,
-  [SMALL_STATE(591)] = 38803,
-  [SMALL_STATE(592)] = 38830,
-  [SMALL_STATE(593)] = 38857,
-  [SMALL_STATE(594)] = 38882,
-  [SMALL_STATE(595)] = 38909,
-  [SMALL_STATE(596)] = 38936,
-  [SMALL_STATE(597)] = 38963,
-  [SMALL_STATE(598)] = 38990,
-  [SMALL_STATE(599)] = 39017,
-  [SMALL_STATE(600)] = 39044,
-  [SMALL_STATE(601)] = 39071,
-  [SMALL_STATE(602)] = 39098,
-  [SMALL_STATE(603)] = 39125,
-  [SMALL_STATE(604)] = 39144,
-  [SMALL_STATE(605)] = 39171,
-  [SMALL_STATE(606)] = 39198,
-  [SMALL_STATE(607)] = 39225,
-  [SMALL_STATE(608)] = 39252,
-  [SMALL_STATE(609)] = 39274,
-  [SMALL_STATE(610)] = 39296,
-  [SMALL_STATE(611)] = 39314,
-  [SMALL_STATE(612)] = 39330,
-  [SMALL_STATE(613)] = 39352,
-  [SMALL_STATE(614)] = 39380,
-  [SMALL_STATE(615)] = 39402,
-  [SMALL_STATE(616)] = 39418,
-  [SMALL_STATE(617)] = 39440,
-  [SMALL_STATE(618)] = 39462,
-  [SMALL_STATE(619)] = 39484,
-  [SMALL_STATE(620)] = 39512,
-  [SMALL_STATE(621)] = 39534,
-  [SMALL_STATE(622)] = 39550,
-  [SMALL_STATE(623)] = 39566,
-  [SMALL_STATE(624)] = 39584,
-  [SMALL_STATE(625)] = 39606,
-  [SMALL_STATE(626)] = 39624,
-  [SMALL_STATE(627)] = 39652,
-  [SMALL_STATE(628)] = 39674,
-  [SMALL_STATE(629)] = 39702,
-  [SMALL_STATE(630)] = 39724,
-  [SMALL_STATE(631)] = 39746,
-  [SMALL_STATE(632)] = 39768,
-  [SMALL_STATE(633)] = 39790,
-  [SMALL_STATE(634)] = 39812,
-  [SMALL_STATE(635)] = 39834,
-  [SMALL_STATE(636)] = 39862,
-  [SMALL_STATE(637)] = 39878,
-  [SMALL_STATE(638)] = 39900,
-  [SMALL_STATE(639)] = 39916,
-  [SMALL_STATE(640)] = 39944,
-  [SMALL_STATE(641)] = 39967,
-  [SMALL_STATE(642)] = 39990,
-  [SMALL_STATE(643)] = 40013,
-  [SMALL_STATE(644)] = 40038,
-  [SMALL_STATE(645)] = 40063,
-  [SMALL_STATE(646)] = 40088,
-  [SMALL_STATE(647)] = 40111,
-  [SMALL_STATE(648)] = 40134,
-  [SMALL_STATE(649)] = 40157,
-  [SMALL_STATE(650)] = 40180,
-  [SMALL_STATE(651)] = 40193,
-  [SMALL_STATE(652)] = 40206,
-  [SMALL_STATE(653)] = 40229,
-  [SMALL_STATE(654)] = 40242,
-  [SMALL_STATE(655)] = 40265,
-  [SMALL_STATE(656)] = 40288,
-  [SMALL_STATE(657)] = 40311,
-  [SMALL_STATE(658)] = 40334,
-  [SMALL_STATE(659)] = 40357,
-  [SMALL_STATE(660)] = 40382,
-  [SMALL_STATE(661)] = 40407,
-  [SMALL_STATE(662)] = 40430,
-  [SMALL_STATE(663)] = 40455,
-  [SMALL_STATE(664)] = 40480,
-  [SMALL_STATE(665)] = 40505,
-  [SMALL_STATE(666)] = 40528,
-  [SMALL_STATE(667)] = 40551,
-  [SMALL_STATE(668)] = 40574,
-  [SMALL_STATE(669)] = 40597,
-  [SMALL_STATE(670)] = 40610,
-  [SMALL_STATE(671)] = 40633,
-  [SMALL_STATE(672)] = 40658,
-  [SMALL_STATE(673)] = 40683,
-  [SMALL_STATE(674)] = 40706,
-  [SMALL_STATE(675)] = 40729,
-  [SMALL_STATE(676)] = 40752,
-  [SMALL_STATE(677)] = 40777,
-  [SMALL_STATE(678)] = 40800,
-  [SMALL_STATE(679)] = 40825,
-  [SMALL_STATE(680)] = 40848,
-  [SMALL_STATE(681)] = 40871,
-  [SMALL_STATE(682)] = 40884,
-  [SMALL_STATE(683)] = 40907,
-  [SMALL_STATE(684)] = 40930,
-  [SMALL_STATE(685)] = 40953,
-  [SMALL_STATE(686)] = 40966,
-  [SMALL_STATE(687)] = 40989,
-  [SMALL_STATE(688)] = 41002,
-  [SMALL_STATE(689)] = 41025,
-  [SMALL_STATE(690)] = 41048,
-  [SMALL_STATE(691)] = 41071,
-  [SMALL_STATE(692)] = 41093,
-  [SMALL_STATE(693)] = 41113,
-  [SMALL_STATE(694)] = 41127,
-  [SMALL_STATE(695)] = 41147,
-  [SMALL_STATE(696)] = 41167,
-  [SMALL_STATE(697)] = 41189,
-  [SMALL_STATE(698)] = 41209,
-  [SMALL_STATE(699)] = 41229,
-  [SMALL_STATE(700)] = 41249,
-  [SMALL_STATE(701)] = 41271,
-  [SMALL_STATE(702)] = 41291,
-  [SMALL_STATE(703)] = 41313,
-  [SMALL_STATE(704)] = 41335,
-  [SMALL_STATE(705)] = 41355,
-  [SMALL_STATE(706)] = 41377,
-  [SMALL_STATE(707)] = 41391,
-  [SMALL_STATE(708)] = 41403,
-  [SMALL_STATE(709)] = 41423,
-  [SMALL_STATE(710)] = 41445,
-  [SMALL_STATE(711)] = 41465,
-  [SMALL_STATE(712)] = 41487,
-  [SMALL_STATE(713)] = 41507,
-  [SMALL_STATE(714)] = 41529,
-  [SMALL_STATE(715)] = 41543,
-  [SMALL_STATE(716)] = 41563,
-  [SMALL_STATE(717)] = 41583,
-  [SMALL_STATE(718)] = 41603,
-  [SMALL_STATE(719)] = 41623,
-  [SMALL_STATE(720)] = 41640,
-  [SMALL_STATE(721)] = 41657,
-  [SMALL_STATE(722)] = 41674,
-  [SMALL_STATE(723)] = 41691,
-  [SMALL_STATE(724)] = 41708,
-  [SMALL_STATE(725)] = 41725,
-  [SMALL_STATE(726)] = 41742,
-  [SMALL_STATE(727)] = 41759,
-  [SMALL_STATE(728)] = 41776,
-  [SMALL_STATE(729)] = 41795,
-  [SMALL_STATE(730)] = 41812,
-  [SMALL_STATE(731)] = 41829,
-  [SMALL_STATE(732)] = 41846,
-  [SMALL_STATE(733)] = 41863,
-  [SMALL_STATE(734)] = 41876,
-  [SMALL_STATE(735)] = 41893,
-  [SMALL_STATE(736)] = 41906,
-  [SMALL_STATE(737)] = 41919,
-  [SMALL_STATE(738)] = 41936,
-  [SMALL_STATE(739)] = 41953,
-  [SMALL_STATE(740)] = 41966,
-  [SMALL_STATE(741)] = 41983,
-  [SMALL_STATE(742)] = 41996,
-  [SMALL_STATE(743)] = 42013,
-  [SMALL_STATE(744)] = 42029,
-  [SMALL_STATE(745)] = 42039,
-  [SMALL_STATE(746)] = 42055,
-  [SMALL_STATE(747)] = 42071,
-  [SMALL_STATE(748)] = 42087,
-  [SMALL_STATE(749)] = 42103,
-  [SMALL_STATE(750)] = 42119,
-  [SMALL_STATE(751)] = 42135,
-  [SMALL_STATE(752)] = 42145,
-  [SMALL_STATE(753)] = 42161,
-  [SMALL_STATE(754)] = 42177,
-  [SMALL_STATE(755)] = 42191,
-  [SMALL_STATE(756)] = 42207,
-  [SMALL_STATE(757)] = 42223,
-  [SMALL_STATE(758)] = 42235,
-  [SMALL_STATE(759)] = 42247,
-  [SMALL_STATE(760)] = 42259,
-  [SMALL_STATE(761)] = 42275,
-  [SMALL_STATE(762)] = 42291,
-  [SMALL_STATE(763)] = 42307,
-  [SMALL_STATE(764)] = 42323,
-  [SMALL_STATE(765)] = 42339,
-  [SMALL_STATE(766)] = 42355,
-  [SMALL_STATE(767)] = 42365,
-  [SMALL_STATE(768)] = 42381,
-  [SMALL_STATE(769)] = 42394,
-  [SMALL_STATE(770)] = 42407,
-  [SMALL_STATE(771)] = 42418,
-  [SMALL_STATE(772)] = 42429,
-  [SMALL_STATE(773)] = 42440,
-  [SMALL_STATE(774)] = 42453,
-  [SMALL_STATE(775)] = 42464,
-  [SMALL_STATE(776)] = 42475,
-  [SMALL_STATE(777)] = 42486,
-  [SMALL_STATE(778)] = 42497,
-  [SMALL_STATE(779)] = 42508,
-  [SMALL_STATE(780)] = 42519,
-  [SMALL_STATE(781)] = 42530,
-  [SMALL_STATE(782)] = 42539,
-  [SMALL_STATE(783)] = 42548,
-  [SMALL_STATE(784)] = 42557,
-  [SMALL_STATE(785)] = 42570,
-  [SMALL_STATE(786)] = 42583,
-  [SMALL_STATE(787)] = 42596,
-  [SMALL_STATE(788)] = 42607,
-  [SMALL_STATE(789)] = 42618,
-  [SMALL_STATE(790)] = 42631,
-  [SMALL_STATE(791)] = 42640,
-  [SMALL_STATE(792)] = 42653,
-  [SMALL_STATE(793)] = 42662,
-  [SMALL_STATE(794)] = 42671,
-  [SMALL_STATE(795)] = 42682,
-  [SMALL_STATE(796)] = 42695,
-  [SMALL_STATE(797)] = 42706,
-  [SMALL_STATE(798)] = 42715,
-  [SMALL_STATE(799)] = 42726,
-  [SMALL_STATE(800)] = 42737,
-  [SMALL_STATE(801)] = 42750,
-  [SMALL_STATE(802)] = 42761,
-  [SMALL_STATE(803)] = 42774,
-  [SMALL_STATE(804)] = 42785,
-  [SMALL_STATE(805)] = 42796,
-  [SMALL_STATE(806)] = 42809,
-  [SMALL_STATE(807)] = 42820,
-  [SMALL_STATE(808)] = 42831,
-  [SMALL_STATE(809)] = 42842,
-  [SMALL_STATE(810)] = 42855,
-  [SMALL_STATE(811)] = 42866,
-  [SMALL_STATE(812)] = 42877,
-  [SMALL_STATE(813)] = 42890,
-  [SMALL_STATE(814)] = 42903,
-  [SMALL_STATE(815)] = 42912,
-  [SMALL_STATE(816)] = 42925,
-  [SMALL_STATE(817)] = 42936,
-  [SMALL_STATE(818)] = 42945,
-  [SMALL_STATE(819)] = 42958,
-  [SMALL_STATE(820)] = 42971,
-  [SMALL_STATE(821)] = 42980,
-  [SMALL_STATE(822)] = 42993,
-  [SMALL_STATE(823)] = 43006,
-  [SMALL_STATE(824)] = 43015,
-  [SMALL_STATE(825)] = 43024,
-  [SMALL_STATE(826)] = 43037,
-  [SMALL_STATE(827)] = 43050,
-  [SMALL_STATE(828)] = 43063,
-  [SMALL_STATE(829)] = 43076,
-  [SMALL_STATE(830)] = 43089,
-  [SMALL_STATE(831)] = 43102,
-  [SMALL_STATE(832)] = 43115,
-  [SMALL_STATE(833)] = 43128,
-  [SMALL_STATE(834)] = 43141,
-  [SMALL_STATE(835)] = 43154,
-  [SMALL_STATE(836)] = 43167,
-  [SMALL_STATE(837)] = 43176,
-  [SMALL_STATE(838)] = 43189,
-  [SMALL_STATE(839)] = 43202,
-  [SMALL_STATE(840)] = 43215,
-  [SMALL_STATE(841)] = 43228,
-  [SMALL_STATE(842)] = 43241,
-  [SMALL_STATE(843)] = 43254,
-  [SMALL_STATE(844)] = 43267,
-  [SMALL_STATE(845)] = 43278,
-  [SMALL_STATE(846)] = 43291,
-  [SMALL_STATE(847)] = 43304,
-  [SMALL_STATE(848)] = 43317,
-  [SMALL_STATE(849)] = 43326,
-  [SMALL_STATE(850)] = 43337,
-  [SMALL_STATE(851)] = 43347,
-  [SMALL_STATE(852)] = 43355,
-  [SMALL_STATE(853)] = 43365,
-  [SMALL_STATE(854)] = 43373,
-  [SMALL_STATE(855)] = 43383,
-  [SMALL_STATE(856)] = 43393,
-  [SMALL_STATE(857)] = 43403,
-  [SMALL_STATE(858)] = 43411,
-  [SMALL_STATE(859)] = 43421,
-  [SMALL_STATE(860)] = 43431,
-  [SMALL_STATE(861)] = 43439,
-  [SMALL_STATE(862)] = 43449,
-  [SMALL_STATE(863)] = 43459,
-  [SMALL_STATE(864)] = 43469,
-  [SMALL_STATE(865)] = 43477,
-  [SMALL_STATE(866)] = 43485,
-  [SMALL_STATE(867)] = 43495,
-  [SMALL_STATE(868)] = 43505,
-  [SMALL_STATE(869)] = 43515,
-  [SMALL_STATE(870)] = 43525,
-  [SMALL_STATE(871)] = 43533,
-  [SMALL_STATE(872)] = 43543,
-  [SMALL_STATE(873)] = 43551,
-  [SMALL_STATE(874)] = 43561,
-  [SMALL_STATE(875)] = 43571,
-  [SMALL_STATE(876)] = 43581,
-  [SMALL_STATE(877)] = 43591,
-  [SMALL_STATE(878)] = 43601,
-  [SMALL_STATE(879)] = 43609,
-  [SMALL_STATE(880)] = 43619,
-  [SMALL_STATE(881)] = 43627,
-  [SMALL_STATE(882)] = 43635,
-  [SMALL_STATE(883)] = 43645,
-  [SMALL_STATE(884)] = 43652,
-  [SMALL_STATE(885)] = 43659,
-  [SMALL_STATE(886)] = 43666,
-  [SMALL_STATE(887)] = 43673,
-  [SMALL_STATE(888)] = 43680,
-  [SMALL_STATE(889)] = 43687,
-  [SMALL_STATE(890)] = 43694,
-  [SMALL_STATE(891)] = 43701,
-  [SMALL_STATE(892)] = 43708,
-  [SMALL_STATE(893)] = 43715,
-  [SMALL_STATE(894)] = 43722,
-  [SMALL_STATE(895)] = 43729,
-  [SMALL_STATE(896)] = 43736,
-  [SMALL_STATE(897)] = 43743,
-  [SMALL_STATE(898)] = 43750,
-  [SMALL_STATE(899)] = 43757,
-  [SMALL_STATE(900)] = 43764,
-  [SMALL_STATE(901)] = 43771,
-  [SMALL_STATE(902)] = 43778,
-  [SMALL_STATE(903)] = 43785,
-  [SMALL_STATE(904)] = 43792,
-  [SMALL_STATE(905)] = 43799,
-  [SMALL_STATE(906)] = 43806,
-  [SMALL_STATE(907)] = 43813,
-  [SMALL_STATE(908)] = 43820,
-  [SMALL_STATE(909)] = 43827,
-  [SMALL_STATE(910)] = 43834,
-  [SMALL_STATE(911)] = 43841,
-  [SMALL_STATE(912)] = 43848,
-  [SMALL_STATE(913)] = 43855,
-  [SMALL_STATE(914)] = 43862,
-  [SMALL_STATE(915)] = 43869,
-  [SMALL_STATE(916)] = 43876,
-  [SMALL_STATE(917)] = 43883,
-  [SMALL_STATE(918)] = 43890,
-  [SMALL_STATE(919)] = 43897,
-  [SMALL_STATE(920)] = 43904,
-  [SMALL_STATE(921)] = 43911,
-  [SMALL_STATE(922)] = 43918,
-  [SMALL_STATE(923)] = 43925,
-  [SMALL_STATE(924)] = 43932,
-  [SMALL_STATE(925)] = 43939,
-  [SMALL_STATE(926)] = 43946,
-  [SMALL_STATE(927)] = 43953,
-  [SMALL_STATE(928)] = 43960,
-  [SMALL_STATE(929)] = 43967,
-  [SMALL_STATE(930)] = 43974,
-  [SMALL_STATE(931)] = 43981,
-  [SMALL_STATE(932)] = 43988,
-  [SMALL_STATE(933)] = 43995,
-  [SMALL_STATE(934)] = 44002,
-  [SMALL_STATE(935)] = 44009,
-  [SMALL_STATE(936)] = 44016,
-  [SMALL_STATE(937)] = 44023,
-  [SMALL_STATE(938)] = 44030,
-  [SMALL_STATE(939)] = 44037,
-  [SMALL_STATE(940)] = 44044,
-  [SMALL_STATE(941)] = 44051,
-  [SMALL_STATE(942)] = 44058,
-  [SMALL_STATE(943)] = 44065,
-  [SMALL_STATE(944)] = 44072,
-  [SMALL_STATE(945)] = 44079,
-  [SMALL_STATE(946)] = 44086,
-  [SMALL_STATE(947)] = 44093,
-  [SMALL_STATE(948)] = 44100,
-  [SMALL_STATE(949)] = 44107,
-  [SMALL_STATE(950)] = 44114,
-  [SMALL_STATE(951)] = 44121,
-  [SMALL_STATE(952)] = 44128,
-  [SMALL_STATE(953)] = 44135,
-  [SMALL_STATE(954)] = 44142,
-  [SMALL_STATE(955)] = 44149,
-  [SMALL_STATE(956)] = 44156,
-  [SMALL_STATE(957)] = 44163,
-  [SMALL_STATE(958)] = 44170,
-  [SMALL_STATE(959)] = 44177,
-  [SMALL_STATE(960)] = 44184,
-  [SMALL_STATE(961)] = 44191,
-  [SMALL_STATE(962)] = 44198,
-  [SMALL_STATE(963)] = 44205,
-  [SMALL_STATE(964)] = 44212,
-  [SMALL_STATE(965)] = 44219,
-  [SMALL_STATE(966)] = 44226,
-  [SMALL_STATE(967)] = 44233,
-  [SMALL_STATE(968)] = 44240,
-  [SMALL_STATE(969)] = 44247,
-  [SMALL_STATE(970)] = 44254,
-  [SMALL_STATE(971)] = 44261,
-  [SMALL_STATE(972)] = 44268,
-  [SMALL_STATE(973)] = 44275,
-  [SMALL_STATE(974)] = 44282,
-  [SMALL_STATE(975)] = 44289,
-  [SMALL_STATE(976)] = 44296,
-  [SMALL_STATE(977)] = 44303,
-  [SMALL_STATE(978)] = 44310,
-  [SMALL_STATE(979)] = 44317,
-  [SMALL_STATE(980)] = 44324,
-  [SMALL_STATE(981)] = 44331,
-  [SMALL_STATE(982)] = 44338,
-  [SMALL_STATE(983)] = 44345,
-  [SMALL_STATE(984)] = 44352,
-  [SMALL_STATE(985)] = 44359,
-  [SMALL_STATE(986)] = 44366,
-  [SMALL_STATE(987)] = 44373,
-  [SMALL_STATE(988)] = 44380,
-  [SMALL_STATE(989)] = 44387,
-  [SMALL_STATE(990)] = 44394,
-  [SMALL_STATE(991)] = 44401,
-  [SMALL_STATE(992)] = 44408,
-  [SMALL_STATE(993)] = 44415,
-  [SMALL_STATE(994)] = 44422,
-  [SMALL_STATE(995)] = 44429,
-  [SMALL_STATE(996)] = 44436,
-  [SMALL_STATE(997)] = 44443,
-  [SMALL_STATE(998)] = 44450,
-  [SMALL_STATE(999)] = 44457,
-  [SMALL_STATE(1000)] = 44464,
-  [SMALL_STATE(1001)] = 44471,
-  [SMALL_STATE(1002)] = 44478,
-  [SMALL_STATE(1003)] = 44485,
-  [SMALL_STATE(1004)] = 44492,
-  [SMALL_STATE(1005)] = 44499,
-  [SMALL_STATE(1006)] = 44506,
-  [SMALL_STATE(1007)] = 44513,
-  [SMALL_STATE(1008)] = 44520,
-  [SMALL_STATE(1009)] = 44527,
-  [SMALL_STATE(1010)] = 44534,
-  [SMALL_STATE(1011)] = 44541,
-  [SMALL_STATE(1012)] = 44548,
-  [SMALL_STATE(1013)] = 44555,
-  [SMALL_STATE(1014)] = 44562,
-  [SMALL_STATE(1015)] = 44569,
-  [SMALL_STATE(1016)] = 44576,
-  [SMALL_STATE(1017)] = 44583,
-  [SMALL_STATE(1018)] = 44590,
-  [SMALL_STATE(1019)] = 44597,
-  [SMALL_STATE(1020)] = 44604,
-  [SMALL_STATE(1021)] = 44611,
-  [SMALL_STATE(1022)] = 44618,
-  [SMALL_STATE(1023)] = 44625,
-  [SMALL_STATE(1024)] = 44632,
-  [SMALL_STATE(1025)] = 44639,
-  [SMALL_STATE(1026)] = 44646,
-  [SMALL_STATE(1027)] = 44653,
-  [SMALL_STATE(1028)] = 44660,
-  [SMALL_STATE(1029)] = 44667,
-  [SMALL_STATE(1030)] = 44674,
-  [SMALL_STATE(1031)] = 44681,
-  [SMALL_STATE(1032)] = 44688,
-  [SMALL_STATE(1033)] = 44695,
-  [SMALL_STATE(1034)] = 44702,
-  [SMALL_STATE(1035)] = 44709,
-  [SMALL_STATE(1036)] = 44716,
-  [SMALL_STATE(1037)] = 44723,
-  [SMALL_STATE(1038)] = 44730,
-  [SMALL_STATE(1039)] = 44737,
+  [SMALL_STATE(70)] = 8038,
+  [SMALL_STATE(71)] = 8133,
+  [SMALL_STATE(72)] = 8258,
+  [SMALL_STATE(73)] = 8383,
+  [SMALL_STATE(74)] = 8478,
+  [SMALL_STATE(75)] = 8603,
+  [SMALL_STATE(76)] = 8728,
+  [SMALL_STATE(77)] = 8853,
+  [SMALL_STATE(78)] = 8948,
+  [SMALL_STATE(79)] = 9043,
+  [SMALL_STATE(80)] = 9138,
+  [SMALL_STATE(81)] = 9191,
+  [SMALL_STATE(82)] = 9244,
+  [SMALL_STATE(83)] = 9297,
+  [SMALL_STATE(84)] = 9350,
+  [SMALL_STATE(85)] = 9405,
+  [SMALL_STATE(86)] = 9458,
+  [SMALL_STATE(87)] = 9511,
+  [SMALL_STATE(88)] = 9564,
+  [SMALL_STATE(89)] = 9617,
+  [SMALL_STATE(90)] = 9670,
+  [SMALL_STATE(91)] = 9723,
+  [SMALL_STATE(92)] = 9776,
+  [SMALL_STATE(93)] = 9829,
+  [SMALL_STATE(94)] = 9882,
+  [SMALL_STATE(95)] = 9935,
+  [SMALL_STATE(96)] = 9988,
+  [SMALL_STATE(97)] = 10041,
+  [SMALL_STATE(98)] = 10094,
+  [SMALL_STATE(99)] = 10149,
+  [SMALL_STATE(100)] = 10202,
+  [SMALL_STATE(101)] = 10255,
+  [SMALL_STATE(102)] = 10310,
+  [SMALL_STATE(103)] = 10363,
+  [SMALL_STATE(104)] = 10416,
+  [SMALL_STATE(105)] = 10469,
+  [SMALL_STATE(106)] = 10522,
+  [SMALL_STATE(107)] = 10575,
+  [SMALL_STATE(108)] = 10628,
+  [SMALL_STATE(109)] = 10681,
+  [SMALL_STATE(110)] = 10734,
+  [SMALL_STATE(111)] = 10787,
+  [SMALL_STATE(112)] = 10840,
+  [SMALL_STATE(113)] = 10893,
+  [SMALL_STATE(114)] = 10946,
+  [SMALL_STATE(115)] = 10999,
+  [SMALL_STATE(116)] = 11052,
+  [SMALL_STATE(117)] = 11105,
+  [SMALL_STATE(118)] = 11158,
+  [SMALL_STATE(119)] = 11211,
+  [SMALL_STATE(120)] = 11263,
+  [SMALL_STATE(121)] = 11315,
+  [SMALL_STATE(122)] = 11425,
+  [SMALL_STATE(123)] = 11535,
+  [SMALL_STATE(124)] = 11645,
+  [SMALL_STATE(125)] = 11755,
+  [SMALL_STATE(126)] = 11865,
+  [SMALL_STATE(127)] = 11975,
+  [SMALL_STATE(128)] = 12027,
+  [SMALL_STATE(129)] = 12137,
+  [SMALL_STATE(130)] = 12247,
+  [SMALL_STATE(131)] = 12357,
+  [SMALL_STATE(132)] = 12409,
+  [SMALL_STATE(133)] = 12519,
+  [SMALL_STATE(134)] = 12571,
+  [SMALL_STATE(135)] = 12681,
+  [SMALL_STATE(136)] = 12791,
+  [SMALL_STATE(137)] = 12901,
+  [SMALL_STATE(138)] = 12953,
+  [SMALL_STATE(139)] = 13063,
+  [SMALL_STATE(140)] = 13173,
+  [SMALL_STATE(141)] = 13225,
+  [SMALL_STATE(142)] = 13335,
+  [SMALL_STATE(143)] = 13445,
+  [SMALL_STATE(144)] = 13497,
+  [SMALL_STATE(145)] = 13607,
+  [SMALL_STATE(146)] = 13711,
+  [SMALL_STATE(147)] = 13815,
+  [SMALL_STATE(148)] = 13916,
+  [SMALL_STATE(149)] = 14017,
+  [SMALL_STATE(150)] = 14118,
+  [SMALL_STATE(151)] = 14219,
+  [SMALL_STATE(152)] = 14320,
+  [SMALL_STATE(153)] = 14421,
+  [SMALL_STATE(154)] = 14522,
+  [SMALL_STATE(155)] = 14623,
+  [SMALL_STATE(156)] = 14724,
+  [SMALL_STATE(157)] = 14825,
+  [SMALL_STATE(158)] = 14926,
+  [SMALL_STATE(159)] = 15027,
+  [SMALL_STATE(160)] = 15128,
+  [SMALL_STATE(161)] = 15229,
+  [SMALL_STATE(162)] = 15330,
+  [SMALL_STATE(163)] = 15431,
+  [SMALL_STATE(164)] = 15532,
+  [SMALL_STATE(165)] = 15633,
+  [SMALL_STATE(166)] = 15734,
+  [SMALL_STATE(167)] = 15835,
+  [SMALL_STATE(168)] = 15936,
+  [SMALL_STATE(169)] = 16037,
+  [SMALL_STATE(170)] = 16138,
+  [SMALL_STATE(171)] = 16239,
+  [SMALL_STATE(172)] = 16340,
+  [SMALL_STATE(173)] = 16441,
+  [SMALL_STATE(174)] = 16542,
+  [SMALL_STATE(175)] = 16643,
+  [SMALL_STATE(176)] = 16744,
+  [SMALL_STATE(177)] = 16845,
+  [SMALL_STATE(178)] = 16946,
+  [SMALL_STATE(179)] = 17047,
+  [SMALL_STATE(180)] = 17148,
+  [SMALL_STATE(181)] = 17249,
+  [SMALL_STATE(182)] = 17350,
+  [SMALL_STATE(183)] = 17451,
+  [SMALL_STATE(184)] = 17552,
+  [SMALL_STATE(185)] = 17653,
+  [SMALL_STATE(186)] = 17754,
+  [SMALL_STATE(187)] = 17855,
+  [SMALL_STATE(188)] = 17956,
+  [SMALL_STATE(189)] = 18057,
+  [SMALL_STATE(190)] = 18158,
+  [SMALL_STATE(191)] = 18259,
+  [SMALL_STATE(192)] = 18360,
+  [SMALL_STATE(193)] = 18461,
+  [SMALL_STATE(194)] = 18562,
+  [SMALL_STATE(195)] = 18663,
+  [SMALL_STATE(196)] = 18764,
+  [SMALL_STATE(197)] = 18865,
+  [SMALL_STATE(198)] = 18966,
+  [SMALL_STATE(199)] = 19067,
+  [SMALL_STATE(200)] = 19168,
+  [SMALL_STATE(201)] = 19269,
+  [SMALL_STATE(202)] = 19370,
+  [SMALL_STATE(203)] = 19471,
+  [SMALL_STATE(204)] = 19572,
+  [SMALL_STATE(205)] = 19673,
+  [SMALL_STATE(206)] = 19774,
+  [SMALL_STATE(207)] = 19875,
+  [SMALL_STATE(208)] = 19976,
+  [SMALL_STATE(209)] = 20077,
+  [SMALL_STATE(210)] = 20178,
+  [SMALL_STATE(211)] = 20279,
+  [SMALL_STATE(212)] = 20380,
+  [SMALL_STATE(213)] = 20481,
+  [SMALL_STATE(214)] = 20528,
+  [SMALL_STATE(215)] = 20575,
+  [SMALL_STATE(216)] = 20622,
+  [SMALL_STATE(217)] = 20669,
+  [SMALL_STATE(218)] = 20716,
+  [SMALL_STATE(219)] = 20763,
+  [SMALL_STATE(220)] = 20810,
+  [SMALL_STATE(221)] = 20857,
+  [SMALL_STATE(222)] = 20904,
+  [SMALL_STATE(223)] = 20951,
+  [SMALL_STATE(224)] = 20998,
+  [SMALL_STATE(225)] = 21045,
+  [SMALL_STATE(226)] = 21092,
+  [SMALL_STATE(227)] = 21139,
+  [SMALL_STATE(228)] = 21186,
+  [SMALL_STATE(229)] = 21233,
+  [SMALL_STATE(230)] = 21280,
+  [SMALL_STATE(231)] = 21327,
+  [SMALL_STATE(232)] = 21376,
+  [SMALL_STATE(233)] = 21423,
+  [SMALL_STATE(234)] = 21470,
+  [SMALL_STATE(235)] = 21517,
+  [SMALL_STATE(236)] = 21566,
+  [SMALL_STATE(237)] = 21613,
+  [SMALL_STATE(238)] = 21660,
+  [SMALL_STATE(239)] = 21707,
+  [SMALL_STATE(240)] = 21754,
+  [SMALL_STATE(241)] = 21801,
+  [SMALL_STATE(242)] = 21848,
+  [SMALL_STATE(243)] = 21897,
+  [SMALL_STATE(244)] = 21944,
+  [SMALL_STATE(245)] = 21991,
+  [SMALL_STATE(246)] = 22040,
+  [SMALL_STATE(247)] = 22087,
+  [SMALL_STATE(248)] = 22134,
+  [SMALL_STATE(249)] = 22181,
+  [SMALL_STATE(250)] = 22228,
+  [SMALL_STATE(251)] = 22275,
+  [SMALL_STATE(252)] = 22322,
+  [SMALL_STATE(253)] = 22369,
+  [SMALL_STATE(254)] = 22416,
+  [SMALL_STATE(255)] = 22463,
+  [SMALL_STATE(256)] = 22510,
+  [SMALL_STATE(257)] = 22557,
+  [SMALL_STATE(258)] = 22604,
+  [SMALL_STATE(259)] = 22651,
+  [SMALL_STATE(260)] = 22698,
+  [SMALL_STATE(261)] = 22745,
+  [SMALL_STATE(262)] = 22792,
+  [SMALL_STATE(263)] = 22841,
+  [SMALL_STATE(264)] = 22888,
+  [SMALL_STATE(265)] = 22935,
+  [SMALL_STATE(266)] = 22982,
+  [SMALL_STATE(267)] = 23031,
+  [SMALL_STATE(268)] = 23078,
+  [SMALL_STATE(269)] = 23125,
+  [SMALL_STATE(270)] = 23172,
+  [SMALL_STATE(271)] = 23219,
+  [SMALL_STATE(272)] = 23268,
+  [SMALL_STATE(273)] = 23315,
+  [SMALL_STATE(274)] = 23362,
+  [SMALL_STATE(275)] = 23409,
+  [SMALL_STATE(276)] = 23456,
+  [SMALL_STATE(277)] = 23503,
+  [SMALL_STATE(278)] = 23550,
+  [SMALL_STATE(279)] = 23597,
+  [SMALL_STATE(280)] = 23644,
+  [SMALL_STATE(281)] = 23691,
+  [SMALL_STATE(282)] = 23738,
+  [SMALL_STATE(283)] = 23785,
+  [SMALL_STATE(284)] = 23834,
+  [SMALL_STATE(285)] = 23881,
+  [SMALL_STATE(286)] = 23928,
+  [SMALL_STATE(287)] = 23975,
+  [SMALL_STATE(288)] = 24022,
+  [SMALL_STATE(289)] = 24069,
+  [SMALL_STATE(290)] = 24116,
+  [SMALL_STATE(291)] = 24163,
+  [SMALL_STATE(292)] = 24210,
+  [SMALL_STATE(293)] = 24257,
+  [SMALL_STATE(294)] = 24304,
+  [SMALL_STATE(295)] = 24351,
+  [SMALL_STATE(296)] = 24398,
+  [SMALL_STATE(297)] = 24445,
+  [SMALL_STATE(298)] = 24494,
+  [SMALL_STATE(299)] = 24541,
+  [SMALL_STATE(300)] = 24588,
+  [SMALL_STATE(301)] = 24635,
+  [SMALL_STATE(302)] = 24682,
+  [SMALL_STATE(303)] = 24729,
+  [SMALL_STATE(304)] = 24776,
+  [SMALL_STATE(305)] = 24823,
+  [SMALL_STATE(306)] = 24870,
+  [SMALL_STATE(307)] = 24917,
+  [SMALL_STATE(308)] = 24964,
+  [SMALL_STATE(309)] = 25011,
+  [SMALL_STATE(310)] = 25058,
+  [SMALL_STATE(311)] = 25107,
+  [SMALL_STATE(312)] = 25154,
+  [SMALL_STATE(313)] = 25201,
+  [SMALL_STATE(314)] = 25248,
+  [SMALL_STATE(315)] = 25295,
+  [SMALL_STATE(316)] = 25342,
+  [SMALL_STATE(317)] = 25389,
+  [SMALL_STATE(318)] = 25436,
+  [SMALL_STATE(319)] = 25483,
+  [SMALL_STATE(320)] = 25530,
+  [SMALL_STATE(321)] = 25577,
+  [SMALL_STATE(322)] = 25624,
+  [SMALL_STATE(323)] = 25671,
+  [SMALL_STATE(324)] = 25720,
+  [SMALL_STATE(325)] = 25767,
+  [SMALL_STATE(326)] = 25814,
+  [SMALL_STATE(327)] = 25863,
+  [SMALL_STATE(328)] = 25910,
+  [SMALL_STATE(329)] = 25957,
+  [SMALL_STATE(330)] = 26004,
+  [SMALL_STATE(331)] = 26051,
+  [SMALL_STATE(332)] = 26098,
+  [SMALL_STATE(333)] = 26145,
+  [SMALL_STATE(334)] = 26192,
+  [SMALL_STATE(335)] = 26239,
+  [SMALL_STATE(336)] = 26286,
+  [SMALL_STATE(337)] = 26333,
+  [SMALL_STATE(338)] = 26380,
+  [SMALL_STATE(339)] = 26427,
+  [SMALL_STATE(340)] = 26474,
+  [SMALL_STATE(341)] = 26521,
+  [SMALL_STATE(342)] = 26568,
+  [SMALL_STATE(343)] = 26617,
+  [SMALL_STATE(344)] = 26664,
+  [SMALL_STATE(345)] = 26711,
+  [SMALL_STATE(346)] = 26758,
+  [SMALL_STATE(347)] = 26805,
+  [SMALL_STATE(348)] = 26852,
+  [SMALL_STATE(349)] = 26899,
+  [SMALL_STATE(350)] = 26948,
+  [SMALL_STATE(351)] = 26997,
+  [SMALL_STATE(352)] = 27044,
+  [SMALL_STATE(353)] = 27091,
+  [SMALL_STATE(354)] = 27138,
+  [SMALL_STATE(355)] = 27185,
+  [SMALL_STATE(356)] = 27232,
+  [SMALL_STATE(357)] = 27279,
+  [SMALL_STATE(358)] = 27326,
+  [SMALL_STATE(359)] = 27373,
+  [SMALL_STATE(360)] = 27420,
+  [SMALL_STATE(361)] = 27467,
+  [SMALL_STATE(362)] = 27514,
+  [SMALL_STATE(363)] = 27561,
+  [SMALL_STATE(364)] = 27608,
+  [SMALL_STATE(365)] = 27655,
+  [SMALL_STATE(366)] = 27702,
+  [SMALL_STATE(367)] = 27749,
+  [SMALL_STATE(368)] = 27796,
+  [SMALL_STATE(369)] = 27843,
+  [SMALL_STATE(370)] = 27890,
+  [SMALL_STATE(371)] = 27937,
+  [SMALL_STATE(372)] = 27984,
+  [SMALL_STATE(373)] = 28031,
+  [SMALL_STATE(374)] = 28078,
+  [SMALL_STATE(375)] = 28125,
+  [SMALL_STATE(376)] = 28172,
+  [SMALL_STATE(377)] = 28219,
+  [SMALL_STATE(378)] = 28266,
+  [SMALL_STATE(379)] = 28313,
+  [SMALL_STATE(380)] = 28360,
+  [SMALL_STATE(381)] = 28407,
+  [SMALL_STATE(382)] = 28454,
+  [SMALL_STATE(383)] = 28501,
+  [SMALL_STATE(384)] = 28548,
+  [SMALL_STATE(385)] = 28595,
+  [SMALL_STATE(386)] = 28642,
+  [SMALL_STATE(387)] = 28689,
+  [SMALL_STATE(388)] = 28736,
+  [SMALL_STATE(389)] = 28783,
+  [SMALL_STATE(390)] = 28830,
+  [SMALL_STATE(391)] = 28877,
+  [SMALL_STATE(392)] = 28924,
+  [SMALL_STATE(393)] = 28971,
+  [SMALL_STATE(394)] = 29018,
+  [SMALL_STATE(395)] = 29065,
+  [SMALL_STATE(396)] = 29112,
+  [SMALL_STATE(397)] = 29159,
+  [SMALL_STATE(398)] = 29206,
+  [SMALL_STATE(399)] = 29253,
+  [SMALL_STATE(400)] = 29300,
+  [SMALL_STATE(401)] = 29347,
+  [SMALL_STATE(402)] = 29394,
+  [SMALL_STATE(403)] = 29441,
+  [SMALL_STATE(404)] = 29488,
+  [SMALL_STATE(405)] = 29535,
+  [SMALL_STATE(406)] = 29582,
+  [SMALL_STATE(407)] = 29629,
+  [SMALL_STATE(408)] = 29676,
+  [SMALL_STATE(409)] = 29722,
+  [SMALL_STATE(410)] = 29768,
+  [SMALL_STATE(411)] = 29814,
+  [SMALL_STATE(412)] = 29860,
+  [SMALL_STATE(413)] = 29906,
+  [SMALL_STATE(414)] = 29952,
+  [SMALL_STATE(415)] = 29998,
+  [SMALL_STATE(416)] = 30044,
+  [SMALL_STATE(417)] = 30090,
+  [SMALL_STATE(418)] = 30136,
+  [SMALL_STATE(419)] = 30182,
+  [SMALL_STATE(420)] = 30228,
+  [SMALL_STATE(421)] = 30274,
+  [SMALL_STATE(422)] = 30320,
+  [SMALL_STATE(423)] = 30366,
+  [SMALL_STATE(424)] = 30412,
+  [SMALL_STATE(425)] = 30458,
+  [SMALL_STATE(426)] = 30504,
+  [SMALL_STATE(427)] = 30550,
+  [SMALL_STATE(428)] = 30596,
+  [SMALL_STATE(429)] = 30642,
+  [SMALL_STATE(430)] = 30688,
+  [SMALL_STATE(431)] = 30734,
+  [SMALL_STATE(432)] = 30780,
+  [SMALL_STATE(433)] = 30826,
+  [SMALL_STATE(434)] = 30872,
+  [SMALL_STATE(435)] = 30918,
+  [SMALL_STATE(436)] = 30964,
+  [SMALL_STATE(437)] = 31010,
+  [SMALL_STATE(438)] = 31056,
+  [SMALL_STATE(439)] = 31102,
+  [SMALL_STATE(440)] = 31148,
+  [SMALL_STATE(441)] = 31194,
+  [SMALL_STATE(442)] = 31240,
+  [SMALL_STATE(443)] = 31286,
+  [SMALL_STATE(444)] = 31332,
+  [SMALL_STATE(445)] = 31378,
+  [SMALL_STATE(446)] = 31424,
+  [SMALL_STATE(447)] = 31470,
+  [SMALL_STATE(448)] = 31516,
+  [SMALL_STATE(449)] = 31607,
+  [SMALL_STATE(450)] = 31668,
+  [SMALL_STATE(451)] = 31741,
+  [SMALL_STATE(452)] = 31816,
+  [SMALL_STATE(453)] = 31881,
+  [SMALL_STATE(454)] = 31940,
+  [SMALL_STATE(455)] = 32021,
+  [SMALL_STATE(456)] = 32102,
+  [SMALL_STATE(457)] = 32171,
+  [SMALL_STATE(458)] = 32234,
+  [SMALL_STATE(459)] = 32299,
+  [SMALL_STATE(460)] = 32358,
+  [SMALL_STATE(461)] = 32435,
+  [SMALL_STATE(462)] = 32519,
+  [SMALL_STATE(463)] = 32603,
+  [SMALL_STATE(464)] = 32687,
+  [SMALL_STATE(465)] = 32771,
+  [SMALL_STATE(466)] = 32855,
+  [SMALL_STATE(467)] = 32928,
+  [SMALL_STATE(468)] = 33001,
+  [SMALL_STATE(469)] = 33074,
+  [SMALL_STATE(470)] = 33147,
+  [SMALL_STATE(471)] = 33220,
+  [SMALL_STATE(472)] = 33293,
+  [SMALL_STATE(473)] = 33352,
+  [SMALL_STATE(474)] = 33427,
+  [SMALL_STATE(475)] = 33498,
+  [SMALL_STATE(476)] = 33573,
+  [SMALL_STATE(477)] = 33642,
+  [SMALL_STATE(478)] = 33709,
+  [SMALL_STATE(479)] = 33780,
+  [SMALL_STATE(480)] = 33839,
+  [SMALL_STATE(481)] = 33914,
+  [SMALL_STATE(482)] = 33977,
+  [SMALL_STATE(483)] = 34046,
+  [SMALL_STATE(484)] = 34105,
+  [SMALL_STATE(485)] = 34172,
+  [SMALL_STATE(486)] = 34235,
+  [SMALL_STATE(487)] = 34288,
+  [SMALL_STATE(488)] = 34347,
+  [SMALL_STATE(489)] = 34422,
+  [SMALL_STATE(490)] = 34475,
+  [SMALL_STATE(491)] = 34530,
+  [SMALL_STATE(492)] = 34583,
+  [SMALL_STATE(493)] = 34640,
+  [SMALL_STATE(494)] = 34699,
+  [SMALL_STATE(495)] = 34758,
+  [SMALL_STATE(496)] = 34821,
+  [SMALL_STATE(497)] = 34888,
+  [SMALL_STATE(498)] = 34957,
+  [SMALL_STATE(499)] = 35028,
+  [SMALL_STATE(500)] = 35103,
+  [SMALL_STATE(501)] = 35178,
+  [SMALL_STATE(502)] = 35253,
+  [SMALL_STATE(503)] = 35310,
+  [SMALL_STATE(504)] = 35367,
+  [SMALL_STATE(505)] = 35422,
+  [SMALL_STATE(506)] = 35477,
+  [SMALL_STATE(507)] = 35530,
+  [SMALL_STATE(508)] = 35583,
+  [SMALL_STATE(509)] = 35642,
+  [SMALL_STATE(510)] = 35695,
+  [SMALL_STATE(511)] = 35770,
+  [SMALL_STATE(512)] = 35823,
+  [SMALL_STATE(513)] = 35876,
+  [SMALL_STATE(514)] = 35931,
+  [SMALL_STATE(515)] = 35988,
+  [SMALL_STATE(516)] = 36047,
+  [SMALL_STATE(517)] = 36110,
+  [SMALL_STATE(518)] = 36177,
+  [SMALL_STATE(519)] = 36246,
+  [SMALL_STATE(520)] = 36317,
+  [SMALL_STATE(521)] = 36376,
+  [SMALL_STATE(522)] = 36451,
+  [SMALL_STATE(523)] = 36526,
+  [SMALL_STATE(524)] = 36579,
+  [SMALL_STATE(525)] = 36632,
+  [SMALL_STATE(526)] = 36687,
+  [SMALL_STATE(527)] = 36758,
+  [SMALL_STATE(528)] = 36827,
+  [SMALL_STATE(529)] = 36894,
+  [SMALL_STATE(530)] = 36957,
+  [SMALL_STATE(531)] = 37016,
+  [SMALL_STATE(532)] = 37073,
+  [SMALL_STATE(533)] = 37108,
+  [SMALL_STATE(534)] = 37143,
+  [SMALL_STATE(535)] = 37178,
+  [SMALL_STATE(536)] = 37213,
+  [SMALL_STATE(537)] = 37245,
+  [SMALL_STATE(538)] = 37276,
+  [SMALL_STATE(539)] = 37307,
+  [SMALL_STATE(540)] = 37338,
+  [SMALL_STATE(541)] = 37369,
+  [SMALL_STATE(542)] = 37400,
+  [SMALL_STATE(543)] = 37431,
+  [SMALL_STATE(544)] = 37462,
+  [SMALL_STATE(545)] = 37493,
+  [SMALL_STATE(546)] = 37540,
+  [SMALL_STATE(547)] = 37587,
+  [SMALL_STATE(548)] = 37634,
+  [SMALL_STATE(549)] = 37681,
+  [SMALL_STATE(550)] = 37728,
+  [SMALL_STATE(551)] = 37775,
+  [SMALL_STATE(552)] = 37819,
+  [SMALL_STATE(553)] = 37863,
+  [SMALL_STATE(554)] = 37907,
+  [SMALL_STATE(555)] = 37951,
+  [SMALL_STATE(556)] = 37995,
+  [SMALL_STATE(557)] = 38039,
+  [SMALL_STATE(558)] = 38058,
+  [SMALL_STATE(559)] = 38077,
+  [SMALL_STATE(560)] = 38096,
+  [SMALL_STATE(561)] = 38115,
+  [SMALL_STATE(562)] = 38134,
+  [SMALL_STATE(563)] = 38153,
+  [SMALL_STATE(564)] = 38190,
+  [SMALL_STATE(565)] = 38209,
+  [SMALL_STATE(566)] = 38228,
+  [SMALL_STATE(567)] = 38247,
+  [SMALL_STATE(568)] = 38270,
+  [SMALL_STATE(569)] = 38293,
+  [SMALL_STATE(570)] = 38319,
+  [SMALL_STATE(571)] = 38345,
+  [SMALL_STATE(572)] = 38375,
+  [SMALL_STATE(573)] = 38391,
+  [SMALL_STATE(574)] = 38417,
+  [SMALL_STATE(575)] = 38433,
+  [SMALL_STATE(576)] = 38459,
+  [SMALL_STATE(577)] = 38485,
+  [SMALL_STATE(578)] = 38501,
+  [SMALL_STATE(579)] = 38527,
+  [SMALL_STATE(580)] = 38553,
+  [SMALL_STATE(581)] = 38579,
+  [SMALL_STATE(582)] = 38605,
+  [SMALL_STATE(583)] = 38631,
+  [SMALL_STATE(584)] = 38657,
+  [SMALL_STATE(585)] = 38683,
+  [SMALL_STATE(586)] = 38699,
+  [SMALL_STATE(587)] = 38725,
+  [SMALL_STATE(588)] = 38741,
+  [SMALL_STATE(589)] = 38757,
+  [SMALL_STATE(590)] = 38783,
+  [SMALL_STATE(591)] = 38809,
+  [SMALL_STATE(592)] = 38836,
+  [SMALL_STATE(593)] = 38863,
+  [SMALL_STATE(594)] = 38888,
+  [SMALL_STATE(595)] = 38915,
+  [SMALL_STATE(596)] = 38942,
+  [SMALL_STATE(597)] = 38969,
+  [SMALL_STATE(598)] = 38996,
+  [SMALL_STATE(599)] = 39023,
+  [SMALL_STATE(600)] = 39050,
+  [SMALL_STATE(601)] = 39077,
+  [SMALL_STATE(602)] = 39104,
+  [SMALL_STATE(603)] = 39131,
+  [SMALL_STATE(604)] = 39150,
+  [SMALL_STATE(605)] = 39177,
+  [SMALL_STATE(606)] = 39204,
+  [SMALL_STATE(607)] = 39231,
+  [SMALL_STATE(608)] = 39258,
+  [SMALL_STATE(609)] = 39280,
+  [SMALL_STATE(610)] = 39302,
+  [SMALL_STATE(611)] = 39320,
+  [SMALL_STATE(612)] = 39336,
+  [SMALL_STATE(613)] = 39358,
+  [SMALL_STATE(614)] = 39386,
+  [SMALL_STATE(615)] = 39408,
+  [SMALL_STATE(616)] = 39424,
+  [SMALL_STATE(617)] = 39446,
+  [SMALL_STATE(618)] = 39468,
+  [SMALL_STATE(619)] = 39490,
+  [SMALL_STATE(620)] = 39518,
+  [SMALL_STATE(621)] = 39540,
+  [SMALL_STATE(622)] = 39556,
+  [SMALL_STATE(623)] = 39572,
+  [SMALL_STATE(624)] = 39590,
+  [SMALL_STATE(625)] = 39612,
+  [SMALL_STATE(626)] = 39630,
+  [SMALL_STATE(627)] = 39658,
+  [SMALL_STATE(628)] = 39680,
+  [SMALL_STATE(629)] = 39708,
+  [SMALL_STATE(630)] = 39730,
+  [SMALL_STATE(631)] = 39752,
+  [SMALL_STATE(632)] = 39774,
+  [SMALL_STATE(633)] = 39796,
+  [SMALL_STATE(634)] = 39818,
+  [SMALL_STATE(635)] = 39840,
+  [SMALL_STATE(636)] = 39868,
+  [SMALL_STATE(637)] = 39884,
+  [SMALL_STATE(638)] = 39906,
+  [SMALL_STATE(639)] = 39922,
+  [SMALL_STATE(640)] = 39950,
+  [SMALL_STATE(641)] = 39973,
+  [SMALL_STATE(642)] = 39996,
+  [SMALL_STATE(643)] = 40019,
+  [SMALL_STATE(644)] = 40044,
+  [SMALL_STATE(645)] = 40069,
+  [SMALL_STATE(646)] = 40094,
+  [SMALL_STATE(647)] = 40117,
+  [SMALL_STATE(648)] = 40140,
+  [SMALL_STATE(649)] = 40163,
+  [SMALL_STATE(650)] = 40186,
+  [SMALL_STATE(651)] = 40199,
+  [SMALL_STATE(652)] = 40212,
+  [SMALL_STATE(653)] = 40235,
+  [SMALL_STATE(654)] = 40248,
+  [SMALL_STATE(655)] = 40271,
+  [SMALL_STATE(656)] = 40294,
+  [SMALL_STATE(657)] = 40317,
+  [SMALL_STATE(658)] = 40340,
+  [SMALL_STATE(659)] = 40363,
+  [SMALL_STATE(660)] = 40388,
+  [SMALL_STATE(661)] = 40413,
+  [SMALL_STATE(662)] = 40436,
+  [SMALL_STATE(663)] = 40461,
+  [SMALL_STATE(664)] = 40486,
+  [SMALL_STATE(665)] = 40511,
+  [SMALL_STATE(666)] = 40534,
+  [SMALL_STATE(667)] = 40557,
+  [SMALL_STATE(668)] = 40580,
+  [SMALL_STATE(669)] = 40603,
+  [SMALL_STATE(670)] = 40616,
+  [SMALL_STATE(671)] = 40639,
+  [SMALL_STATE(672)] = 40664,
+  [SMALL_STATE(673)] = 40689,
+  [SMALL_STATE(674)] = 40712,
+  [SMALL_STATE(675)] = 40735,
+  [SMALL_STATE(676)] = 40758,
+  [SMALL_STATE(677)] = 40783,
+  [SMALL_STATE(678)] = 40806,
+  [SMALL_STATE(679)] = 40831,
+  [SMALL_STATE(680)] = 40854,
+  [SMALL_STATE(681)] = 40877,
+  [SMALL_STATE(682)] = 40890,
+  [SMALL_STATE(683)] = 40913,
+  [SMALL_STATE(684)] = 40936,
+  [SMALL_STATE(685)] = 40959,
+  [SMALL_STATE(686)] = 40972,
+  [SMALL_STATE(687)] = 40995,
+  [SMALL_STATE(688)] = 41008,
+  [SMALL_STATE(689)] = 41031,
+  [SMALL_STATE(690)] = 41054,
+  [SMALL_STATE(691)] = 41077,
+  [SMALL_STATE(692)] = 41099,
+  [SMALL_STATE(693)] = 41119,
+  [SMALL_STATE(694)] = 41133,
+  [SMALL_STATE(695)] = 41153,
+  [SMALL_STATE(696)] = 41173,
+  [SMALL_STATE(697)] = 41195,
+  [SMALL_STATE(698)] = 41215,
+  [SMALL_STATE(699)] = 41235,
+  [SMALL_STATE(700)] = 41255,
+  [SMALL_STATE(701)] = 41277,
+  [SMALL_STATE(702)] = 41297,
+  [SMALL_STATE(703)] = 41319,
+  [SMALL_STATE(704)] = 41341,
+  [SMALL_STATE(705)] = 41361,
+  [SMALL_STATE(706)] = 41383,
+  [SMALL_STATE(707)] = 41397,
+  [SMALL_STATE(708)] = 41409,
+  [SMALL_STATE(709)] = 41429,
+  [SMALL_STATE(710)] = 41451,
+  [SMALL_STATE(711)] = 41471,
+  [SMALL_STATE(712)] = 41493,
+  [SMALL_STATE(713)] = 41513,
+  [SMALL_STATE(714)] = 41535,
+  [SMALL_STATE(715)] = 41549,
+  [SMALL_STATE(716)] = 41569,
+  [SMALL_STATE(717)] = 41589,
+  [SMALL_STATE(718)] = 41609,
+  [SMALL_STATE(719)] = 41629,
+  [SMALL_STATE(720)] = 41646,
+  [SMALL_STATE(721)] = 41663,
+  [SMALL_STATE(722)] = 41680,
+  [SMALL_STATE(723)] = 41697,
+  [SMALL_STATE(724)] = 41714,
+  [SMALL_STATE(725)] = 41731,
+  [SMALL_STATE(726)] = 41748,
+  [SMALL_STATE(727)] = 41765,
+  [SMALL_STATE(728)] = 41782,
+  [SMALL_STATE(729)] = 41801,
+  [SMALL_STATE(730)] = 41818,
+  [SMALL_STATE(731)] = 41835,
+  [SMALL_STATE(732)] = 41852,
+  [SMALL_STATE(733)] = 41869,
+  [SMALL_STATE(734)] = 41882,
+  [SMALL_STATE(735)] = 41899,
+  [SMALL_STATE(736)] = 41912,
+  [SMALL_STATE(737)] = 41925,
+  [SMALL_STATE(738)] = 41942,
+  [SMALL_STATE(739)] = 41959,
+  [SMALL_STATE(740)] = 41972,
+  [SMALL_STATE(741)] = 41989,
+  [SMALL_STATE(742)] = 42002,
+  [SMALL_STATE(743)] = 42019,
+  [SMALL_STATE(744)] = 42035,
+  [SMALL_STATE(745)] = 42045,
+  [SMALL_STATE(746)] = 42061,
+  [SMALL_STATE(747)] = 42077,
+  [SMALL_STATE(748)] = 42093,
+  [SMALL_STATE(749)] = 42109,
+  [SMALL_STATE(750)] = 42125,
+  [SMALL_STATE(751)] = 42141,
+  [SMALL_STATE(752)] = 42151,
+  [SMALL_STATE(753)] = 42167,
+  [SMALL_STATE(754)] = 42183,
+  [SMALL_STATE(755)] = 42197,
+  [SMALL_STATE(756)] = 42213,
+  [SMALL_STATE(757)] = 42229,
+  [SMALL_STATE(758)] = 42241,
+  [SMALL_STATE(759)] = 42253,
+  [SMALL_STATE(760)] = 42265,
+  [SMALL_STATE(761)] = 42281,
+  [SMALL_STATE(762)] = 42297,
+  [SMALL_STATE(763)] = 42313,
+  [SMALL_STATE(764)] = 42329,
+  [SMALL_STATE(765)] = 42345,
+  [SMALL_STATE(766)] = 42361,
+  [SMALL_STATE(767)] = 42371,
+  [SMALL_STATE(768)] = 42387,
+  [SMALL_STATE(769)] = 42400,
+  [SMALL_STATE(770)] = 42413,
+  [SMALL_STATE(771)] = 42424,
+  [SMALL_STATE(772)] = 42435,
+  [SMALL_STATE(773)] = 42446,
+  [SMALL_STATE(774)] = 42459,
+  [SMALL_STATE(775)] = 42470,
+  [SMALL_STATE(776)] = 42481,
+  [SMALL_STATE(777)] = 42492,
+  [SMALL_STATE(778)] = 42503,
+  [SMALL_STATE(779)] = 42514,
+  [SMALL_STATE(780)] = 42525,
+  [SMALL_STATE(781)] = 42536,
+  [SMALL_STATE(782)] = 42545,
+  [SMALL_STATE(783)] = 42554,
+  [SMALL_STATE(784)] = 42563,
+  [SMALL_STATE(785)] = 42576,
+  [SMALL_STATE(786)] = 42589,
+  [SMALL_STATE(787)] = 42602,
+  [SMALL_STATE(788)] = 42613,
+  [SMALL_STATE(789)] = 42624,
+  [SMALL_STATE(790)] = 42637,
+  [SMALL_STATE(791)] = 42646,
+  [SMALL_STATE(792)] = 42659,
+  [SMALL_STATE(793)] = 42668,
+  [SMALL_STATE(794)] = 42677,
+  [SMALL_STATE(795)] = 42688,
+  [SMALL_STATE(796)] = 42701,
+  [SMALL_STATE(797)] = 42712,
+  [SMALL_STATE(798)] = 42721,
+  [SMALL_STATE(799)] = 42732,
+  [SMALL_STATE(800)] = 42743,
+  [SMALL_STATE(801)] = 42756,
+  [SMALL_STATE(802)] = 42767,
+  [SMALL_STATE(803)] = 42780,
+  [SMALL_STATE(804)] = 42791,
+  [SMALL_STATE(805)] = 42802,
+  [SMALL_STATE(806)] = 42815,
+  [SMALL_STATE(807)] = 42826,
+  [SMALL_STATE(808)] = 42837,
+  [SMALL_STATE(809)] = 42848,
+  [SMALL_STATE(810)] = 42861,
+  [SMALL_STATE(811)] = 42872,
+  [SMALL_STATE(812)] = 42883,
+  [SMALL_STATE(813)] = 42896,
+  [SMALL_STATE(814)] = 42909,
+  [SMALL_STATE(815)] = 42918,
+  [SMALL_STATE(816)] = 42931,
+  [SMALL_STATE(817)] = 42942,
+  [SMALL_STATE(818)] = 42951,
+  [SMALL_STATE(819)] = 42964,
+  [SMALL_STATE(820)] = 42977,
+  [SMALL_STATE(821)] = 42986,
+  [SMALL_STATE(822)] = 42999,
+  [SMALL_STATE(823)] = 43012,
+  [SMALL_STATE(824)] = 43021,
+  [SMALL_STATE(825)] = 43030,
+  [SMALL_STATE(826)] = 43043,
+  [SMALL_STATE(827)] = 43056,
+  [SMALL_STATE(828)] = 43069,
+  [SMALL_STATE(829)] = 43082,
+  [SMALL_STATE(830)] = 43095,
+  [SMALL_STATE(831)] = 43108,
+  [SMALL_STATE(832)] = 43121,
+  [SMALL_STATE(833)] = 43134,
+  [SMALL_STATE(834)] = 43147,
+  [SMALL_STATE(835)] = 43160,
+  [SMALL_STATE(836)] = 43173,
+  [SMALL_STATE(837)] = 43182,
+  [SMALL_STATE(838)] = 43195,
+  [SMALL_STATE(839)] = 43208,
+  [SMALL_STATE(840)] = 43221,
+  [SMALL_STATE(841)] = 43234,
+  [SMALL_STATE(842)] = 43247,
+  [SMALL_STATE(843)] = 43260,
+  [SMALL_STATE(844)] = 43273,
+  [SMALL_STATE(845)] = 43284,
+  [SMALL_STATE(846)] = 43297,
+  [SMALL_STATE(847)] = 43310,
+  [SMALL_STATE(848)] = 43323,
+  [SMALL_STATE(849)] = 43332,
+  [SMALL_STATE(850)] = 43343,
+  [SMALL_STATE(851)] = 43353,
+  [SMALL_STATE(852)] = 43361,
+  [SMALL_STATE(853)] = 43371,
+  [SMALL_STATE(854)] = 43379,
+  [SMALL_STATE(855)] = 43389,
+  [SMALL_STATE(856)] = 43399,
+  [SMALL_STATE(857)] = 43409,
+  [SMALL_STATE(858)] = 43417,
+  [SMALL_STATE(859)] = 43427,
+  [SMALL_STATE(860)] = 43437,
+  [SMALL_STATE(861)] = 43445,
+  [SMALL_STATE(862)] = 43455,
+  [SMALL_STATE(863)] = 43465,
+  [SMALL_STATE(864)] = 43475,
+  [SMALL_STATE(865)] = 43483,
+  [SMALL_STATE(866)] = 43491,
+  [SMALL_STATE(867)] = 43501,
+  [SMALL_STATE(868)] = 43511,
+  [SMALL_STATE(869)] = 43521,
+  [SMALL_STATE(870)] = 43531,
+  [SMALL_STATE(871)] = 43539,
+  [SMALL_STATE(872)] = 43549,
+  [SMALL_STATE(873)] = 43557,
+  [SMALL_STATE(874)] = 43567,
+  [SMALL_STATE(875)] = 43577,
+  [SMALL_STATE(876)] = 43587,
+  [SMALL_STATE(877)] = 43597,
+  [SMALL_STATE(878)] = 43607,
+  [SMALL_STATE(879)] = 43615,
+  [SMALL_STATE(880)] = 43625,
+  [SMALL_STATE(881)] = 43633,
+  [SMALL_STATE(882)] = 43641,
+  [SMALL_STATE(883)] = 43651,
+  [SMALL_STATE(884)] = 43658,
+  [SMALL_STATE(885)] = 43665,
+  [SMALL_STATE(886)] = 43672,
+  [SMALL_STATE(887)] = 43679,
+  [SMALL_STATE(888)] = 43686,
+  [SMALL_STATE(889)] = 43693,
+  [SMALL_STATE(890)] = 43700,
+  [SMALL_STATE(891)] = 43707,
+  [SMALL_STATE(892)] = 43714,
+  [SMALL_STATE(893)] = 43721,
+  [SMALL_STATE(894)] = 43728,
+  [SMALL_STATE(895)] = 43735,
+  [SMALL_STATE(896)] = 43742,
+  [SMALL_STATE(897)] = 43749,
+  [SMALL_STATE(898)] = 43756,
+  [SMALL_STATE(899)] = 43763,
+  [SMALL_STATE(900)] = 43770,
+  [SMALL_STATE(901)] = 43777,
+  [SMALL_STATE(902)] = 43784,
+  [SMALL_STATE(903)] = 43791,
+  [SMALL_STATE(904)] = 43798,
+  [SMALL_STATE(905)] = 43805,
+  [SMALL_STATE(906)] = 43812,
+  [SMALL_STATE(907)] = 43819,
+  [SMALL_STATE(908)] = 43826,
+  [SMALL_STATE(909)] = 43833,
+  [SMALL_STATE(910)] = 43840,
+  [SMALL_STATE(911)] = 43847,
+  [SMALL_STATE(912)] = 43854,
+  [SMALL_STATE(913)] = 43861,
+  [SMALL_STATE(914)] = 43868,
+  [SMALL_STATE(915)] = 43875,
+  [SMALL_STATE(916)] = 43882,
+  [SMALL_STATE(917)] = 43889,
+  [SMALL_STATE(918)] = 43896,
+  [SMALL_STATE(919)] = 43903,
+  [SMALL_STATE(920)] = 43910,
+  [SMALL_STATE(921)] = 43917,
+  [SMALL_STATE(922)] = 43924,
+  [SMALL_STATE(923)] = 43931,
+  [SMALL_STATE(924)] = 43938,
+  [SMALL_STATE(925)] = 43945,
+  [SMALL_STATE(926)] = 43952,
+  [SMALL_STATE(927)] = 43959,
+  [SMALL_STATE(928)] = 43966,
+  [SMALL_STATE(929)] = 43973,
+  [SMALL_STATE(930)] = 43980,
+  [SMALL_STATE(931)] = 43987,
+  [SMALL_STATE(932)] = 43994,
+  [SMALL_STATE(933)] = 44001,
+  [SMALL_STATE(934)] = 44008,
+  [SMALL_STATE(935)] = 44015,
+  [SMALL_STATE(936)] = 44022,
+  [SMALL_STATE(937)] = 44029,
+  [SMALL_STATE(938)] = 44036,
+  [SMALL_STATE(939)] = 44043,
+  [SMALL_STATE(940)] = 44050,
+  [SMALL_STATE(941)] = 44057,
+  [SMALL_STATE(942)] = 44064,
+  [SMALL_STATE(943)] = 44071,
+  [SMALL_STATE(944)] = 44078,
+  [SMALL_STATE(945)] = 44085,
+  [SMALL_STATE(946)] = 44092,
+  [SMALL_STATE(947)] = 44099,
+  [SMALL_STATE(948)] = 44106,
+  [SMALL_STATE(949)] = 44113,
+  [SMALL_STATE(950)] = 44120,
+  [SMALL_STATE(951)] = 44127,
+  [SMALL_STATE(952)] = 44134,
+  [SMALL_STATE(953)] = 44141,
+  [SMALL_STATE(954)] = 44148,
+  [SMALL_STATE(955)] = 44155,
+  [SMALL_STATE(956)] = 44162,
+  [SMALL_STATE(957)] = 44169,
+  [SMALL_STATE(958)] = 44176,
+  [SMALL_STATE(959)] = 44183,
+  [SMALL_STATE(960)] = 44190,
+  [SMALL_STATE(961)] = 44197,
+  [SMALL_STATE(962)] = 44204,
+  [SMALL_STATE(963)] = 44211,
+  [SMALL_STATE(964)] = 44218,
+  [SMALL_STATE(965)] = 44225,
+  [SMALL_STATE(966)] = 44232,
+  [SMALL_STATE(967)] = 44239,
+  [SMALL_STATE(968)] = 44246,
+  [SMALL_STATE(969)] = 44253,
+  [SMALL_STATE(970)] = 44260,
+  [SMALL_STATE(971)] = 44267,
+  [SMALL_STATE(972)] = 44274,
+  [SMALL_STATE(973)] = 44281,
+  [SMALL_STATE(974)] = 44288,
+  [SMALL_STATE(975)] = 44295,
+  [SMALL_STATE(976)] = 44302,
+  [SMALL_STATE(977)] = 44309,
+  [SMALL_STATE(978)] = 44316,
+  [SMALL_STATE(979)] = 44323,
+  [SMALL_STATE(980)] = 44330,
+  [SMALL_STATE(981)] = 44337,
+  [SMALL_STATE(982)] = 44344,
+  [SMALL_STATE(983)] = 44351,
+  [SMALL_STATE(984)] = 44358,
+  [SMALL_STATE(985)] = 44365,
+  [SMALL_STATE(986)] = 44372,
+  [SMALL_STATE(987)] = 44379,
+  [SMALL_STATE(988)] = 44386,
+  [SMALL_STATE(989)] = 44393,
+  [SMALL_STATE(990)] = 44400,
+  [SMALL_STATE(991)] = 44407,
+  [SMALL_STATE(992)] = 44414,
+  [SMALL_STATE(993)] = 44421,
+  [SMALL_STATE(994)] = 44428,
+  [SMALL_STATE(995)] = 44435,
+  [SMALL_STATE(996)] = 44442,
+  [SMALL_STATE(997)] = 44449,
+  [SMALL_STATE(998)] = 44456,
+  [SMALL_STATE(999)] = 44463,
+  [SMALL_STATE(1000)] = 44470,
+  [SMALL_STATE(1001)] = 44477,
+  [SMALL_STATE(1002)] = 44484,
+  [SMALL_STATE(1003)] = 44491,
+  [SMALL_STATE(1004)] = 44498,
+  [SMALL_STATE(1005)] = 44505,
+  [SMALL_STATE(1006)] = 44512,
+  [SMALL_STATE(1007)] = 44519,
+  [SMALL_STATE(1008)] = 44526,
+  [SMALL_STATE(1009)] = 44533,
+  [SMALL_STATE(1010)] = 44540,
+  [SMALL_STATE(1011)] = 44547,
+  [SMALL_STATE(1012)] = 44554,
+  [SMALL_STATE(1013)] = 44561,
+  [SMALL_STATE(1014)] = 44568,
+  [SMALL_STATE(1015)] = 44575,
+  [SMALL_STATE(1016)] = 44582,
+  [SMALL_STATE(1017)] = 44589,
+  [SMALL_STATE(1018)] = 44596,
+  [SMALL_STATE(1019)] = 44603,
+  [SMALL_STATE(1020)] = 44610,
+  [SMALL_STATE(1021)] = 44617,
+  [SMALL_STATE(1022)] = 44624,
+  [SMALL_STATE(1023)] = 44631,
+  [SMALL_STATE(1024)] = 44638,
+  [SMALL_STATE(1025)] = 44645,
+  [SMALL_STATE(1026)] = 44652,
+  [SMALL_STATE(1027)] = 44659,
+  [SMALL_STATE(1028)] = 44666,
+  [SMALL_STATE(1029)] = 44673,
+  [SMALL_STATE(1030)] = 44680,
+  [SMALL_STATE(1031)] = 44687,
+  [SMALL_STATE(1032)] = 44694,
+  [SMALL_STATE(1033)] = 44701,
+  [SMALL_STATE(1034)] = 44708,
+  [SMALL_STATE(1035)] = 44715,
+  [SMALL_STATE(1036)] = 44722,
+  [SMALL_STATE(1037)] = 44729,
+  [SMALL_STATE(1038)] = 44736,
+  [SMALL_STATE(1039)] = 44743,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -42331,7 +42466,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [537] = {.entry = {.count = 1, .reusable = false}}, SHIFT(718),
   [539] = {.entry = {.count = 1, .reusable = false}}, SHIFT(695),
   [541] = {.entry = {.count = 1, .reusable = false}}, SHIFT(692),
-  [543] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
+  [543] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
   [545] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
   [547] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_uni_term, 1),
   [549] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uni_term, 1),
@@ -42352,19 +42487,19 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [579] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_infix_expr, 2, .production_id = 6),
   [581] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_types, 1),
   [583] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_types, 1),
-  [585] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
+  [585] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
   [587] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
   [589] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
-  [591] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
+  [591] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
   [593] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
   [595] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [597] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
+  [597] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
   [599] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
   [601] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
-  [603] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
+  [603] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
   [605] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
   [607] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
-  [609] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [609] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
   [611] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
   [613] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
   [615] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_let_in_block, 7, .production_id = 59),
@@ -42436,9 +42571,9 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [749] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_uni_record_repeat1, 2), SHIFT_REPEAT(606),
   [752] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annot_atom, 2),
   [754] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annot_atom, 2, .production_id = 20),
-  [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
   [758] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annot, 1, .production_id = 10),
-  [760] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(75),
+  [760] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(71),
   [763] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(128),
   [766] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2),
   [768] = {.entry = {.count = 1, .reusable = false}}, SHIFT(706),
@@ -42626,28 +42761,28 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1146] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fun_expr_repeat1, 2),
   [1148] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fun_expr_repeat1, 2), SHIFT_REPEAT(691),
   [1151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(219),
-  [1153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [1153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
   [1155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(746),
   [1157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match, 2, .production_id = 24),
-  [1159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [1159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
   [1161] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_destruct_repeat1, 2), SHIFT_REPEAT(571),
   [1164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_destruct_repeat1, 2),
-  [1166] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(77),
+  [1166] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(74),
   [1169] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(132),
-  [1172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [1174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [1172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [1174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
   [1176] = {.entry = {.count = 1, .reusable = false}}, SHIFT(603),
   [1178] = {.entry = {.count = 1, .reusable = false}}, SHIFT(761),
-  [1180] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(76),
+  [1180] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(72),
   [1183] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(136),
-  [1186] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(78),
+  [1186] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(75),
   [1189] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(121),
-  [1192] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(79),
+  [1192] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(76),
   [1195] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(123),
-  [1198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [1198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
   [1200] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_chunk_literal_single, 1),
   [1202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_chunk_literal_single, 1),
-  [1204] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(74),
+  [1204] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(69),
   [1207] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annot_repeat1, 2), SHIFT_REPEAT(129),
   [1210] = {.entry = {.count = 1, .reusable = true}}, SHIFT(764),
   [1212] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1024),


### PR DESCRIPTION
This adds `not_exported` as a metadata annotation to the grammar.