### PR TITLE
Correctly parse string interpolation with preceding quotes

### DIFF
--- a/corpus/string.txt
+++ b/corpus/string.txt
@@ -324,3 +324,45 @@ mix-s-s%%""%%
               (str_chunks_multi
                 (multstr_start)
                 (multstr_end)))))))))
+
+================================================================================
+ambiguous interpolation
+================================================================================
+
+
+nix-s%"
+export PATH="%{inputs.coreutils}/bin:$PATH"
+"%
+
+--------------------------------------------------------------------------------
+(term
+  (uni_term
+    (infix_expr
+      (applicative
+        (record_operand
+          (atom
+            (str_chunks
+              (str_chunks_multi
+                (multstr_start)
+                (chunk_literal_multi
+                  (mult_str_literal))
+                (chunk_literal_multi
+                  (double_quote))
+                (chunk_expr
+                  (interpolation_start)
+                  (term
+                    (uni_term
+                      (infix_expr
+                        (applicative
+                          (record_operand
+                            (record_operation_chain
+                              (record_operand
+                                (atom
+                                  (ident)))
+                              (ident)))))))
+                  (interpolation_end))
+                (chunk_literal_multi
+                  (mult_str_literal))
+                (chunk_literal_multi
+                  (double_quote))
+                (multstr_end)))))))))

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -197,9 +197,10 @@ struct Scanner {
 
     expected_percent_count.pop_back();
 
-    // An END is fully scanned when we started with an '"' (precondition of
-    // this function) and consumed all %-signs.
-    return count == 0;
+    // An END is fully scanned when we started with an '"' (precondition of this
+    // function) and consumed all %-signs, assuming the next character doesn't
+    // indicate the start of an interpolation.
+    return count == 0 && lookahead(lexer) != '{';
   }
 
   // Precondition of this function is that the lookahead is '"'


### PR DESCRIPTION
Check if the next character following a possible closing string delimiter is a `{` before committing to the string ending.

Fixes #26 