### PR TITLE
Update version to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-nickel"
 description = "Nickel grammar for the tree-sitter parsing library"
-version = "0.2.0"
+version = "0.3.0"
 keywords = ["incremental", "parsing", "nickel"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/nickel-lang/tree-sitter-nickel"


### PR DESCRIPTION
We need a version released on crates.io that match the queries of `topiary-queries` 0.4.3 that can be used by Nickel. This PR bump the version and prepare for a release of tree-sitter-nickel that includes the latest changes to the grammar, namely the support for let-blocks.