### PR TITLE
Nix: remove flake-utils + add overlay

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ trim_trailing_whitespace = false
 trim_trailing_whitespace = false
 end_of_line = unset
 
-[**.{js,json,cc,scm}]
+[**.{js,json,cc,scm,nix}]
 indent_style = space
 indent_size = 2

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1717112898,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,14 @@
       });
     in
     {
+      overlays = {
+        tree-sitter-grammars = final: prev: {
+          tree-sitter-grammars = prev.tree-sitter-grammars // {
+            tree-sitter-nickel = self.packages.${prev.system}.tree-sitter-nickel;
+          };
+        };
+      };
+
       packages = forAllSystems ({ system, pkgs, ... }: {
         tree-sitter-nickel = pkgs.callPackage (nixpkgs + "/pkgs/development/tools/parsing/tree-sitter/grammar.nix") { }
           {

--- a/flake.nix
+++ b/flake.nix
@@ -3,57 +3,76 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        version = "0.2.0";
+  outputs = { self, nixpkgs, ... }@inputs:
+    let
+      version = "0.2.0";
+
+      # Matches pkgs.tree-sitter
+      supportedSystems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "i686-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      pkgsFor = nixpkgs.lib.genAttrs supportedSystems (system: import nixpkgs {
+        inherit system;
+      });
+
+      forAllSystems = fn: nixpkgs.lib.genAttrs supportedSystems (system: fn rec {
+        inherit system;
+        pkgs = pkgsFor.${system};
+        inherit (pkgs) lib;
+      });
+    in
+    {
+      packages = forAllSystems ({ system, pkgs, ... }: {
         tree-sitter-nickel = pkgs.callPackage (nixpkgs + "/pkgs/development/tools/parsing/tree-sitter/grammar.nix") { }
           {
             language = "nickel";
             src = ./.;
             inherit version;
           };
-      in
-      {
-        packages.default = tree-sitter-nickel;
 
-        devShells.default = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [
-            nodejs_latest
-            tree-sitter
-            clang
+        default = self.packages.${system}.tree-sitter-nickel;
+      });
+
+      devShells = forAllSystems ({ system, pkgs, ... }: {
+        default = pkgs.mkShell {
+          inputsFrom = builtins.concatMap builtins.attrValues [
+            self.checks.${system}
+            self.packages.${system}
           ];
-          profile = ''
-            export npm_config_build_from_source=true
-          '';
-        };
-
-        checks.default =
-          pkgs.stdenv.mkDerivation {
-            pname = "tree-sitter-nickel-test";
-            inherit version;
-
-            src = self;
-
-            nativeBuildInputs = with pkgs; [
-              nodejs_latest
-              tree-sitter
-              clang
-            ];
-
-            buildPhase = ''
-              echo 'Running corpus tests'
-              HOME=$(mktemp -d) tree-sitter test
-            '';
-
-            # Write nothing to the store
-            installPhase = "touch $out";
+          env = {
+            npm_config_build_from_source = true;
           };
-      }
-    )
-  ;
+        };
+      });
+
+      checks = forAllSystems ({ pkgs, ... }: {
+        default = pkgs.stdenv.mkDerivation {
+          pname = "tree-sitter-nickel-test";
+          inherit version;
+
+          src = self;
+
+          nativeBuildInputs = [
+            pkgs.nodejs_latest
+            pkgs.tree-sitter
+            pkgs.clang
+          ];
+
+          buildPhase = ''
+            echo 'Running corpus tests'
+            HOME=$(mktemp -d) tree-sitter test
+          '';
+
+          # Write nothing to the store
+          installPhase = "touch $out";
+        };
+      });
+    };
 }


### PR DESCRIPTION
You knew this day was coming 😛

As mentioned elsewhere, there isn’t much point in having a dependency _just_ for a for loop. This will remove the dependency but also expose `i686-linux` which is supported by `tree-sitter` but is not in `flake-utils`’s `defaultSystems` (which no one seems to check what the defaults are).

Additionally, Nix was missing from the EditorConfig & might as well expose the `tree-sitter-nickel` as an overlay that automatically appends it into `tree-sitter-grammars` for convenience (such as for upstream Topiary). All of this & is still a net-negative lines of code diff.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.