### PR TITLE
Add missing tree-sitter-language dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ path = "bindings/rust/lib.rs"
 
 [dependencies]
 tree-sitter = ">=0.21"
+tree-sitter-language = "0.1.5"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
In order to release as 0.4.0 on crates.io, I needed to fix a missing dependency. Backporting to master.