### PR TITLE
[tree-sitter-nickel] Fix doc test to use valid Nickel code

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -4,8 +4,7 @@
 //! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = r#"
-//! "#;
+//! let code = r#"let x = 42 in x"#;
 //! let mut parser = tree_sitter::Parser::new();
 //! let language = tree_sitter_nickel::LANGUAGE;
 //! parser


### PR DESCRIPTION
The doc test example was using a string containing just '"' which is invalid Nickel syntax (unclosed string literal). This caused the tree-sitter parser to report an error, making the doc test fail.

Changed the example to use valid Nickel code 'let x = 42 in x' instead.