### PR TITLE
Remove unused merge keyword

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -58,7 +58,7 @@ module.exports = grammar({
     ////////////////////////////
     // LEXER RELATED RULES (lexer.rs)
     ////////////////////////////
-    keyword: _ => token(/if|then|else|forall|in|let|rec|match|null|true|false|fun|import|merge|default|doc|force|optional|priority|not_exported/),
+    keyword: _ => token(/if|then|else|forall|in|let|rec|match|null|true|false|fun|import|default|doc|force|optional|priority|not_exported/),
 
     num_literal: _ => /([0-9]*\.?[0-9]+([eE][+\-]?[0-9]+)?)|0((b[01]+)|(o[0-7]+)|(x[0-9a-fA-F]+))/,
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -11,7 +11,7 @@
       "type": "TOKEN",
       "content": {
         "type": "PATTERN",
-        "value": "if|then|else|forall|in|let|rec|match|null|true|false|fun|import|merge|default|doc|force|optional|priority|not_exported"
+        "value": "if|then|else|forall|in|let|rec|match|null|true|false|fun|import|default|doc|force|optional|priority|not_exported"
       }
     },
     "num_literal": {

--- a/src/parser.c
+++ b/src/parser.c
@@ -2929,445 +2929,444 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(97);
+      if (eof) ADVANCE(95);
       ADVANCE_MAP(
-        '!', 240,
-        '"', 227,
-        '%', 226,
-        '&', 241,
+        '!', 236,
+        '"', 223,
+        '%', 222,
+        '&', 237,
         '\'', 22,
-        '(', 214,
-        ')', 215,
-        '*', 236,
-        '+', 238,
-        ',', 205,
-        '-', 239,
-        '.', 210,
-        '/', 237,
-        '0', 100,
-        ':', 201,
-        ';', 213,
-        '<', 243,
-        '=', 203,
-        '>', 245,
-        '?', 225,
-        '@', 221,
-        'A', 176,
-        'B', 158,
-        'D', 192,
-        'N', 187,
-        'S', 184,
-        '[', 217,
-        '\\', 93,
-        ']', 218,
-        '_', 222,
-        'd', 127,
-        'e', 145,
-        'f', 115,
-        'i', 151,
-        'l', 133,
-        'm', 119,
-        'n', 160,
-        'o', 166,
-        'p', 169,
-        'r', 128,
-        't', 140,
-        '{', 207,
-        '|', 198,
-        '}', 208,
+        '(', 210,
+        ')', 211,
+        '*', 232,
+        '+', 234,
+        ',', 201,
+        '-', 235,
+        '.', 206,
+        '/', 233,
+        '0', 98,
+        ':', 197,
+        ';', 209,
+        '<', 239,
+        '=', 199,
+        '>', 241,
+        '?', 221,
+        '@', 217,
+        'A', 172,
+        'B', 155,
+        'D', 188,
+        'N', 183,
+        'S', 180,
+        '[', 213,
+        '\\', 91,
+        ']', 214,
+        '_', 218,
+        'd', 125,
+        'e', 142,
+        'f', 113,
+        'i', 148,
+        'l', 131,
+        'm', 117,
+        'n', 157,
+        'o', 163,
+        'p', 166,
+        'r', 126,
+        't', 137,
+        '{', 203,
+        '|', 194,
+        '}', 204,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(0);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(101);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(99);
       if (('C' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 1:
       ADVANCE_MAP(
         '!', 18,
-        '%', 226,
-        '&', 241,
+        '%', 222,
+        '&', 237,
         '\'', 22,
-        '(', 214,
-        ')', 215,
-        '*', 236,
-        '+', 238,
-        ',', 205,
-        '-', 239,
-        '.', 210,
-        '/', 237,
-        '0', 100,
-        ':', 201,
-        ';', 213,
-        '<', 243,
-        '=', 203,
-        '>', 245,
-        '?', 225,
-        '@', 221,
-        'B', 158,
-        'D', 192,
-        'N', 187,
-        'S', 184,
-        '[', 217,
-        ']', 218,
-        '_', 222,
-        'd', 127,
-        'e', 145,
-        'f', 115,
-        'i', 151,
-        'l', 133,
-        'm', 119,
-        'n', 160,
-        'o', 167,
-        'p', 169,
-        'r', 128,
-        't', 140,
-        '{', 207,
-        '|', 198,
-        '}', 208,
+        '(', 210,
+        ')', 211,
+        '*', 232,
+        '+', 234,
+        ',', 201,
+        '-', 235,
+        '.', 206,
+        '/', 233,
+        '0', 98,
+        ':', 197,
+        ';', 209,
+        '<', 239,
+        '=', 199,
+        '>', 241,
+        '?', 221,
+        '@', 217,
+        'B', 155,
+        'D', 188,
+        'N', 183,
+        'S', 180,
+        '[', 213,
+        ']', 214,
+        '_', 218,
+        'd', 125,
+        'e', 142,
+        'f', 113,
+        'i', 148,
+        'l', 131,
+        'm', 117,
+        'n', 157,
+        'o', 164,
+        'p', 166,
+        'r', 126,
+        't', 137,
+        '{', 203,
+        '|', 194,
+        '}', 204,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(1);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(101);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(99);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 2:
-      if (lookahead == '"') ADVANCE(227);
-      if (lookahead == '%') ADVANCE(226);
-      if (lookahead == '\\') ADVANCE(230);
+      if (lookahead == '"') ADVANCE(223);
+      if (lookahead == '%') ADVANCE(222);
+      if (lookahead == '\\') ADVANCE(226);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(231);
-      if (lookahead != 0) ADVANCE(232);
+          lookahead == ' ') ADVANCE(227);
+      if (lookahead != 0) ADVANCE(228);
       END_STATE();
     case 3:
       ADVANCE_MAP(
-        '%', 226,
+        '%', 222,
         '\'', 22,
-        '(', 214,
-        ',', 205,
-        '.', 87,
-        '0', 100,
-        ';', 213,
-        '=', 202,
-        '?', 225,
-        'B', 158,
-        'D', 192,
-        'N', 187,
-        'S', 184,
-        '[', 217,
-        '_', 222,
-        'd', 127,
-        'e', 145,
-        'f', 115,
-        'i', 151,
-        'l', 133,
-        'm', 119,
-        'n', 160,
-        'o', 167,
-        'p', 169,
-        'r', 128,
-        't', 140,
-        '{', 207,
+        '(', 210,
+        ',', 201,
+        '.', 85,
+        '0', 98,
+        ';', 209,
+        '=', 198,
+        '?', 221,
+        'B', 155,
+        'D', 188,
+        'N', 183,
+        'S', 180,
+        '[', 213,
+        '_', 218,
+        'd', 125,
+        'e', 142,
+        'f', 113,
+        'i', 148,
+        'l', 131,
+        'm', 117,
+        'n', 157,
+        'o', 164,
+        'p', 166,
+        'r', 126,
+        't', 137,
+        '{', 203,
         '|', 21,
-        '}', 208,
+        '}', 204,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(3);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(101);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(99);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 4:
-      if (lookahead == '%') ADVANCE(226);
-      if (lookahead == '\\') ADVANCE(93);
+      if (lookahead == '%') ADVANCE(222);
+      if (lookahead == '\\') ADVANCE(91);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(228);
+          lookahead == ' ') ADVANCE(224);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(229);
+          lookahead != '"') ADVANCE(225);
       END_STATE();
     case 5:
       ADVANCE_MAP(
         '\'', 22,
-        '(', 214,
-        ',', 205,
+        '(', 210,
+        ',', 201,
         '-', 17,
-        '.', 89,
-        '0', 107,
-        ':', 201,
-        ';', 213,
-        '=', 202,
-        '?', 225,
-        '[', 216,
-        ']', 218,
-        '_', 222,
-        'd', 127,
-        'e', 145,
-        'f', 115,
-        'i', 151,
-        'l', 133,
-        'm', 119,
-        'n', 160,
-        'o', 166,
-        'p', 169,
-        'r', 128,
-        't', 140,
-        '{', 207,
-        '|', 197,
-        '}', 208,
+        '.', 87,
+        '0', 105,
+        ':', 197,
+        ';', 209,
+        '=', 198,
+        '?', 221,
+        '[', 212,
+        ']', 214,
+        '_', 218,
+        'd', 125,
+        'e', 142,
+        'f', 113,
+        'i', 148,
+        'l', 131,
+        'm', 117,
+        'n', 157,
+        'o', 163,
+        'p', 166,
+        'r', 126,
+        't', 137,
+        '{', 203,
+        '|', 193,
+        '}', 204,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(5);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(108);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(106);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 6:
       ADVANCE_MAP(
         '\'', 22,
-        '(', 214,
+        '(', 210,
         '-', 17,
         '.', 14,
-        '0', 107,
+        '0', 105,
         '=', 19,
-        '@', 221,
-        '[', 216,
-        ']', 218,
-        '_', 222,
-        'd', 127,
-        'e', 145,
-        'f', 115,
-        'i', 151,
-        'l', 133,
-        'm', 119,
-        'n', 160,
-        'o', 167,
-        'p', 169,
-        'r', 128,
-        't', 140,
-        '{', 207,
-        '}', 208,
+        '@', 217,
+        '[', 212,
+        ']', 214,
+        '_', 218,
+        'd', 125,
+        'e', 142,
+        'f', 113,
+        'i', 148,
+        'l', 131,
+        'm', 117,
+        'n', 157,
+        'o', 164,
+        'p', 166,
+        'r', 126,
+        't', 137,
+        '{', 203,
+        '}', 204,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(6);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(108);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(106);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 7:
       ADVANCE_MAP(
         '\'', 22,
-        '(', 214,
+        '(', 210,
         '-', 17,
-        '.', 89,
-        '0', 107,
+        '.', 87,
+        '0', 105,
         '=', 19,
-        '[', 216,
-        '_', 222,
-        'd', 127,
-        'e', 145,
-        'f', 115,
-        'i', 151,
-        'l', 133,
-        'm', 119,
-        'n', 160,
-        'o', 166,
-        'p', 169,
-        'r', 128,
-        't', 140,
-        '{', 207,
+        '[', 212,
+        '_', 218,
+        'd', 125,
+        'e', 142,
+        'f', 113,
+        'i', 148,
+        'l', 131,
+        'm', 117,
+        'n', 157,
+        'o', 163,
+        'p', 166,
+        'r', 126,
+        't', 137,
+        '{', 203,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(7);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(108);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(106);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 8:
       ADVANCE_MAP(
-        ')', 215,
-        ',', 205,
-        '.', 209,
-        ':', 201,
-        ';', 213,
-        '=', 204,
-        ']', 218,
+        ')', 211,
+        ',', 201,
+        '.', 205,
+        ':', 197,
+        ';', 209,
+        '=', 200,
+        ']', 214,
         'd', 34,
-        'e', 48,
+        'e', 47,
         'f', 26,
-        'i', 52,
+        'i', 51,
         'l', 38,
         'm', 28,
         'n', 56,
-        'o', 61,
-        'p', 65,
+        'o', 60,
+        'p', 64,
         'r', 35,
-        't', 44,
-        '|', 200,
-        '}', 208,
+        't', 43,
+        '|', 196,
+        '}', 204,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(8);
       END_STATE();
     case 9:
-      if (lookahead == ')') ADVANCE(215);
+      if (lookahead == ')') ADVANCE(211);
       if (lookahead == '_') ADVANCE(24);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(9);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(234);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(230);
       END_STATE();
     case 10:
       ADVANCE_MAP(
-        ',', 205,
-        '.', 209,
-        ':', 201,
-        ';', 213,
-        '=', 202,
-        '@', 221,
-        ']', 218,
-        'o', 64,
-        '|', 197,
-        '}', 208,
+        ',', 201,
+        '.', 205,
+        ':', 197,
+        ';', 209,
+        '=', 198,
+        '@', 217,
+        ']', 214,
+        'o', 63,
+        '|', 193,
+        '}', 204,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(10);
       END_STATE();
     case 11:
       ADVANCE_MAP(
-        ',', 205,
-        '.', 209,
-        ':', 201,
-        ';', 213,
-        '=', 202,
-        '[', 216,
-        ']', 218,
+        ',', 201,
+        '.', 205,
+        ':', 197,
+        ';', 209,
+        '=', 198,
+        '[', 212,
+        ']', 214,
         '_', 23,
-        '|', 200,
-        '}', 208,
+        '|', 196,
+        '}', 204,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(11);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 12:
       ADVANCE_MAP(
-        ',', 205,
-        '.', 209,
-        ';', 213,
+        ',', 201,
+        '.', 205,
+        ';', 209,
         '=', 19,
-        '@', 221,
+        '@', 217,
         'd', 34,
-        'e', 48,
+        'e', 47,
         'f', 26,
-        'i', 52,
+        'i', 51,
         'l', 38,
         'm', 28,
         'n', 56,
-        'o', 61,
-        'p', 65,
+        'o', 60,
+        'p', 64,
         'r', 35,
-        't', 44,
+        't', 43,
         '|', 21,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(12);
       END_STATE();
     case 13:
-      if (lookahead == '.') ADVANCE(220);
+      if (lookahead == '.') ADVANCE(216);
       END_STATE();
     case 14:
-      if (lookahead == '.') ADVANCE(220);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(109);
+      if (lookahead == '.') ADVANCE(216);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(107);
       END_STATE();
     case 15:
       if (lookahead == '.') ADVANCE(13);
-      if (lookahead == ';') ADVANCE(213);
-      if (lookahead == '_') ADVANCE(222);
-      if (lookahead == 'i') ADVANCE(156);
-      if (lookahead == '}') ADVANCE(208);
+      if (lookahead == ';') ADVANCE(209);
+      if (lookahead == '_') ADVANCE(218);
+      if (lookahead == 'i') ADVANCE(153);
+      if (lookahead == '}') ADVANCE(204);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(15);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 16:
       if (lookahead == '.') ADVANCE(13);
       if (lookahead == '_') ADVANCE(23);
-      if (lookahead == '}') ADVANCE(208);
+      if (lookahead == '}') ADVANCE(204);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(16);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 17:
-      if (lookahead == '.') ADVANCE(89);
-      if (lookahead == '0') ADVANCE(107);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(108);
+      if (lookahead == '.') ADVANCE(87);
+      if (lookahead == '0') ADVANCE(105);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(106);
       END_STATE();
     case 18:
-      if (lookahead == '=') ADVANCE(248);
+      if (lookahead == '=') ADVANCE(244);
       END_STATE();
     case 19:
-      if (lookahead == '>') ADVANCE(206);
+      if (lookahead == '>') ADVANCE(202);
       END_STATE();
     case 20:
-      if (lookahead == 'D') ADVANCE(192);
+      if (lookahead == 'D') ADVANCE(188);
       if (lookahead == '_') ADVANCE(23);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(20);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 21:
-      if (lookahead == ']') ADVANCE(256);
+      if (lookahead == ']') ADVANCE(252);
       END_STATE();
     case 22:
       if (lookahead == '_') ADVANCE(22);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(196);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(192);
       END_STATE();
     case 23:
       if (lookahead == '_') ADVANCE(23);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 24:
       if (lookahead == '_') ADVANCE(24);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(234);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(230);
       END_STATE();
     case 25:
       if (lookahead == '_') ADVANCE(39);
       END_STATE();
     case 26:
-      if (lookahead == 'a') ADVANCE(48);
-      if (lookahead == 'o') ADVANCE(66);
-      if (lookahead == 'u') ADVANCE(53);
+      if (lookahead == 'a') ADVANCE(47);
+      if (lookahead == 'o') ADVANCE(65);
+      if (lookahead == 'u') ADVANCE(52);
       END_STATE();
     case 27:
-      if (lookahead == 'a') ADVANCE(51);
+      if (lookahead == 'a') ADVANCE(50);
       if (lookahead == 'c') ADVANCE(37);
       END_STATE();
     case 28:
-      if (lookahead == 'a') ADVANCE(74);
-      if (lookahead == 'e') ADVANCE(67);
+      if (lookahead == 'a') ADVANCE(72);
       END_STATE();
     case 29:
-      if (lookahead == 'a') ADVANCE(77);
+      if (lookahead == 'a') ADVANCE(75);
       END_STATE();
     case 30:
-      if (lookahead == 'a') ADVANCE(49);
+      if (lookahead == 'a') ADVANCE(48);
       END_STATE();
     case 31:
-      if (lookahead == 'c') ADVANCE(98);
+      if (lookahead == 'c') ADVANCE(96);
       END_STATE();
     case 32:
-      if (lookahead == 'c') ADVANCE(43);
+      if (lookahead == 'c') ADVANCE(42);
       END_STATE();
     case 33:
-      if (lookahead == 'd') ADVANCE(98);
+      if (lookahead == 'd') ADVANCE(96);
       END_STATE();
     case 34:
       if (lookahead == 'e') ADVANCE(41);
@@ -3377,16 +3376,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'e') ADVANCE(31);
       END_STATE();
     case 36:
-      if (lookahead == 'e') ADVANCE(53);
+      if (lookahead == 'e') ADVANCE(52);
       END_STATE();
     case 37:
-      if (lookahead == 'e') ADVANCE(98);
+      if (lookahead == 'e') ADVANCE(96);
       END_STATE();
     case 38:
-      if (lookahead == 'e') ADVANCE(71);
+      if (lookahead == 'e') ADVANCE(69);
       END_STATE();
     case 39:
-      if (lookahead == 'e') ADVANCE(79);
+      if (lookahead == 'e') ADVANCE(77);
       END_STATE();
     case 40:
       if (lookahead == 'e') ADVANCE(33);
@@ -3395,459 +3394,432 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'f') ADVANCE(29);
       END_STATE();
     case 42:
-      if (lookahead == 'g') ADVANCE(37);
+      if (lookahead == 'h') ADVANCE(96);
       END_STATE();
     case 43:
-      if (lookahead == 'h') ADVANCE(98);
+      if (lookahead == 'h') ADVANCE(36);
+      if (lookahead == 'r') ADVANCE(76);
       END_STATE();
     case 44:
-      if (lookahead == 'h') ADVANCE(36);
-      if (lookahead == 'r') ADVANCE(78);
+      if (lookahead == 'i') ADVANCE(58);
       END_STATE();
     case 45:
-      if (lookahead == 'i') ADVANCE(59);
+      if (lookahead == 'i') ADVANCE(54);
       END_STATE();
     case 46:
-      if (lookahead == 'i') ADVANCE(55);
+      if (lookahead == 'i') ADVANCE(71);
       END_STATE();
     case 47:
-      if (lookahead == 'i') ADVANCE(73);
+      if (lookahead == 'l') ADVANCE(68);
       END_STATE();
     case 48:
-      if (lookahead == 'l') ADVANCE(70);
+      if (lookahead == 'l') ADVANCE(96);
       END_STATE();
     case 49:
-      if (lookahead == 'l') ADVANCE(98);
+      if (lookahead == 'l') ADVANCE(69);
       END_STATE();
     case 50:
-      if (lookahead == 'l') ADVANCE(71);
+      if (lookahead == 'l') ADVANCE(48);
       END_STATE();
     case 51:
-      if (lookahead == 'l') ADVANCE(49);
+      if (lookahead == 'm') ADVANCE(59);
+      if (lookahead == 'f' ||
+          lookahead == 'n') ADVANCE(96);
       END_STATE();
     case 52:
-      if (lookahead == 'm') ADVANCE(60);
-      if (lookahead == 'f' ||
-          lookahead == 'n') ADVANCE(98);
+      if (lookahead == 'n') ADVANCE(96);
       END_STATE();
     case 53:
-      if (lookahead == 'n') ADVANCE(98);
-      END_STATE();
-    case 54:
       if (lookahead == 'n') ADVANCE(30);
       END_STATE();
+    case 54:
+      if (lookahead == 'o') ADVANCE(53);
+      END_STATE();
     case 55:
-      if (lookahead == 'o') ADVANCE(54);
+      if (lookahead == 'o') ADVANCE(62);
       END_STATE();
     case 56:
-      if (lookahead == 'o') ADVANCE(72);
-      if (lookahead == 'u') ADVANCE(51);
-      END_STATE();
-    case 57:
-      if (lookahead == 'o') ADVANCE(63);
-      END_STATE();
-    case 58:
-      if (lookahead == 'o') ADVANCE(69);
-      END_STATE();
-    case 59:
-      if (lookahead == 'o') ADVANCE(68);
-      END_STATE();
-    case 60:
-      if (lookahead == 'p') ADVANCE(57);
-      END_STATE();
-    case 61:
-      if (lookahead == 'p') ADVANCE(76);
-      if (lookahead == 'r') ADVANCE(223);
-      END_STATE();
-    case 62:
-      if (lookahead == 'p') ADVANCE(58);
-      END_STATE();
-    case 63:
-      if (lookahead == 'r') ADVANCE(71);
-      END_STATE();
-    case 64:
-      if (lookahead == 'r') ADVANCE(223);
-      END_STATE();
-    case 65:
-      if (lookahead == 'r') ADVANCE(45);
-      END_STATE();
-    case 66:
-      if (lookahead == 'r') ADVANCE(27);
-      END_STATE();
-    case 67:
-      if (lookahead == 'r') ADVANCE(42);
-      END_STATE();
-    case 68:
-      if (lookahead == 'r') ADVANCE(47);
-      END_STATE();
-    case 69:
-      if (lookahead == 'r') ADVANCE(75);
-      END_STATE();
-    case 70:
-      if (lookahead == 's') ADVANCE(37);
-      END_STATE();
-    case 71:
-      if (lookahead == 't') ADVANCE(98);
-      END_STATE();
-    case 72:
-      if (lookahead == 't') ADVANCE(25);
-      END_STATE();
-    case 73:
-      if (lookahead == 't') ADVANCE(80);
-      END_STATE();
-    case 74:
-      if (lookahead == 't') ADVANCE(32);
-      END_STATE();
-    case 75:
-      if (lookahead == 't') ADVANCE(40);
-      END_STATE();
-    case 76:
-      if (lookahead == 't') ADVANCE(46);
-      END_STATE();
-    case 77:
+      if (lookahead == 'o') ADVANCE(70);
       if (lookahead == 'u') ADVANCE(50);
       END_STATE();
-    case 78:
+    case 57:
+      if (lookahead == 'o') ADVANCE(67);
+      END_STATE();
+    case 58:
+      if (lookahead == 'o') ADVANCE(66);
+      END_STATE();
+    case 59:
+      if (lookahead == 'p') ADVANCE(55);
+      END_STATE();
+    case 60:
+      if (lookahead == 'p') ADVANCE(74);
+      if (lookahead == 'r') ADVANCE(219);
+      END_STATE();
+    case 61:
+      if (lookahead == 'p') ADVANCE(57);
+      END_STATE();
+    case 62:
+      if (lookahead == 'r') ADVANCE(69);
+      END_STATE();
+    case 63:
+      if (lookahead == 'r') ADVANCE(219);
+      END_STATE();
+    case 64:
+      if (lookahead == 'r') ADVANCE(44);
+      END_STATE();
+    case 65:
+      if (lookahead == 'r') ADVANCE(27);
+      END_STATE();
+    case 66:
+      if (lookahead == 'r') ADVANCE(46);
+      END_STATE();
+    case 67:
+      if (lookahead == 'r') ADVANCE(73);
+      END_STATE();
+    case 68:
+      if (lookahead == 's') ADVANCE(37);
+      END_STATE();
+    case 69:
+      if (lookahead == 't') ADVANCE(96);
+      END_STATE();
+    case 70:
+      if (lookahead == 't') ADVANCE(25);
+      END_STATE();
+    case 71:
+      if (lookahead == 't') ADVANCE(78);
+      END_STATE();
+    case 72:
+      if (lookahead == 't') ADVANCE(32);
+      END_STATE();
+    case 73:
+      if (lookahead == 't') ADVANCE(40);
+      END_STATE();
+    case 74:
+      if (lookahead == 't') ADVANCE(45);
+      END_STATE();
+    case 75:
+      if (lookahead == 'u') ADVANCE(49);
+      END_STATE();
+    case 76:
       if (lookahead == 'u') ADVANCE(37);
       END_STATE();
+    case 77:
+      if (lookahead == 'x') ADVANCE(61);
+      END_STATE();
+    case 78:
+      if (lookahead == 'y') ADVANCE(96);
+      END_STATE();
     case 79:
-      if (lookahead == 'x') ADVANCE(62);
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(86);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(103);
       END_STATE();
     case 80:
-      if (lookahead == 'y') ADVANCE(98);
-      END_STATE();
-    case 81:
       if (lookahead == '+' ||
           lookahead == '-') ADVANCE(88);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(105);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(110);
+      END_STATE();
+    case 81:
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(101);
       END_STATE();
     case 82:
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(90);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(112);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(108);
       END_STATE();
     case 83:
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(103);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(102);
       END_STATE();
     case 84:
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(110);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(109);
       END_STATE();
     case 85:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(104);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(100);
       END_STATE();
     case 86:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(111);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(103);
       END_STATE();
     case 87:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(102);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(107);
       END_STATE();
     case 88:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(105);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(110);
       END_STATE();
     case 89:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(109);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(104);
       END_STATE();
     case 90:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(112);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(111);
       END_STATE();
     case 91:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(106);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(229);
       END_STATE();
     case 92:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(113);
+      if (eof) ADVANCE(95);
+      ADVANCE_MAP(
+        '!', 236,
+        '%', 222,
+        '&', 237,
+        '\'', 22,
+        '(', 210,
+        ')', 211,
+        '*', 232,
+        '+', 234,
+        ',', 201,
+        '-', 235,
+        '.', 206,
+        '/', 233,
+        '0', 98,
+        ':', 197,
+        ';', 209,
+        '<', 239,
+        '=', 199,
+        '>', 241,
+        '?', 221,
+        '@', 217,
+        'A', 172,
+        'B', 155,
+        'D', 188,
+        'N', 183,
+        'S', 180,
+        '[', 213,
+        ']', 214,
+        '_', 218,
+        'd', 125,
+        'e', 142,
+        'f', 113,
+        'i', 148,
+        'l', 131,
+        'm', 117,
+        'n', 157,
+        'o', 164,
+        'p', 166,
+        'r', 126,
+        't', 137,
+        '{', 203,
+        '|', 195,
+        '}', 204,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(92);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(99);
+      if (('C' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 93:
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(233);
+      if (eof) ADVANCE(95);
+      ADVANCE_MAP(
+        '!', 18,
+        '%', 222,
+        '&', 237,
+        '\'', 22,
+        '(', 210,
+        ')', 211,
+        '*', 232,
+        '+', 234,
+        ',', 201,
+        '-', 235,
+        '.', 206,
+        '/', 233,
+        '0', 98,
+        ':', 197,
+        ';', 209,
+        '<', 239,
+        '=', 199,
+        '>', 241,
+        '?', 221,
+        '@', 217,
+        'B', 155,
+        'D', 188,
+        'N', 183,
+        'S', 180,
+        '[', 213,
+        ']', 214,
+        '_', 218,
+        'd', 125,
+        'e', 142,
+        'f', 113,
+        'i', 148,
+        'l', 131,
+        'm', 117,
+        'n', 157,
+        'o', 164,
+        'p', 166,
+        'r', 126,
+        't', 137,
+        '{', 203,
+        '|', 195,
+        '}', 204,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(93);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(99);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 94:
-      if (eof) ADVANCE(97);
-      ADVANCE_MAP(
-        '!', 240,
-        '%', 226,
-        '&', 241,
-        '\'', 22,
-        '(', 214,
-        ')', 215,
-        '*', 236,
-        '+', 238,
-        ',', 205,
-        '-', 239,
-        '.', 210,
-        '/', 237,
-        '0', 100,
-        ':', 201,
-        ';', 213,
-        '<', 243,
-        '=', 203,
-        '>', 245,
-        '?', 225,
-        '@', 221,
-        'A', 176,
-        'B', 158,
-        'D', 192,
-        'N', 187,
-        'S', 184,
-        '[', 217,
-        ']', 218,
-        '_', 222,
-        'd', 127,
-        'e', 145,
-        'f', 115,
-        'i', 151,
-        'l', 133,
-        'm', 119,
-        'n', 160,
-        'o', 167,
-        'p', 169,
-        'r', 128,
-        't', 140,
-        '{', 207,
-        '|', 199,
-        '}', 208,
-      );
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(94);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(101);
-      if (('C' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 95:
-      if (eof) ADVANCE(97);
+      if (eof) ADVANCE(95);
       ADVANCE_MAP(
         '!', 18,
-        '%', 226,
-        '&', 241,
-        '\'', 22,
-        '(', 214,
-        ')', 215,
-        '*', 236,
-        '+', 238,
-        ',', 205,
-        '-', 239,
-        '.', 210,
-        '/', 237,
-        '0', 100,
-        ':', 201,
-        ';', 213,
-        '<', 243,
-        '=', 203,
-        '>', 245,
-        '?', 225,
-        '@', 221,
-        'B', 158,
-        'D', 192,
-        'N', 187,
-        'S', 184,
-        '[', 217,
-        ']', 218,
-        '_', 222,
-        'd', 127,
-        'e', 145,
-        'f', 115,
-        'i', 151,
-        'l', 133,
-        'm', 119,
-        'n', 160,
-        'o', 167,
-        'p', 169,
-        'r', 128,
-        't', 140,
-        '{', 207,
-        '|', 199,
-        '}', 208,
-      );
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(95);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(101);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 96:
-      if (eof) ADVANCE(97);
-      ADVANCE_MAP(
-        '!', 18,
-        '%', 226,
-        '&', 241,
-        ')', 215,
-        '*', 236,
-        '+', 238,
-        ',', 205,
-        '-', 239,
-        '/', 237,
-        ':', 201,
-        ';', 213,
-        '<', 243,
-        '=', 203,
-        '>', 245,
-        '?', 225,
-        '@', 221,
-        ']', 218,
+        '%', 222,
+        '&', 237,
+        ')', 211,
+        '*', 232,
+        '+', 234,
+        ',', 201,
+        '-', 235,
+        '/', 233,
+        ':', 197,
+        ';', 209,
+        '<', 239,
+        '=', 199,
+        '>', 241,
+        '?', 221,
+        '@', 217,
+        ']', 214,
         'd', 34,
-        'e', 48,
+        'e', 47,
         'f', 26,
-        'i', 52,
+        'i', 51,
         'l', 38,
         'm', 28,
         'n', 56,
-        'o', 61,
-        'p', 65,
+        'o', 60,
+        'p', 64,
         'r', 35,
-        't', 44,
-        '|', 199,
-        '}', 208,
+        't', 43,
+        '|', 195,
+        '}', 204,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(96);
+          lookahead == ' ') SKIP(94);
       END_STATE();
-    case 97:
+    case 95:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 98:
+    case 96:
       ACCEPT_TOKEN(sym_keyword);
       END_STATE();
-    case 99:
+    case 97:
       ACCEPT_TOKEN(sym_keyword);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 98:
+      ACCEPT_TOKEN(sym_num_literal);
+      if (lookahead == '.') ADVANCE(85);
+      if (lookahead == 'b') ADVANCE(81);
+      if (lookahead == 'o') ADVANCE(83);
+      if (lookahead == 'x') ADVANCE(89);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(79);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(99);
+      END_STATE();
+    case 99:
+      ACCEPT_TOKEN(sym_num_literal);
+      if (lookahead == '.') ADVANCE(85);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(79);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(99);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym_num_literal);
-      if (lookahead == '.') ADVANCE(87);
-      if (lookahead == 'b') ADVANCE(83);
-      if (lookahead == 'o') ADVANCE(85);
-      if (lookahead == 'x') ADVANCE(91);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(81);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(101);
+          lookahead == 'e') ADVANCE(79);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(100);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym_num_literal);
-      if (lookahead == '.') ADVANCE(87);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(81);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(101);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(101);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(sym_num_literal);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(81);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(102);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(102);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(sym_num_literal);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(103);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(103);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(sym_num_literal);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(104);
-      END_STATE();
-    case 105:
-      ACCEPT_TOKEN(sym_num_literal);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(105);
-      END_STATE();
-    case 106:
-      ACCEPT_TOKEN(sym_num_literal);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(106);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(104);
+      END_STATE();
+    case 105:
+      ACCEPT_TOKEN(sym_signed_num_literal);
+      if (lookahead == '.') ADVANCE(87);
+      if (lookahead == 'b') ADVANCE(82);
+      if (lookahead == 'o') ADVANCE(84);
+      if (lookahead == 'x') ADVANCE(90);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(80);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(106);
+      END_STATE();
+    case 106:
+      ACCEPT_TOKEN(sym_signed_num_literal);
+      if (lookahead == '.') ADVANCE(87);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(80);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(106);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(sym_signed_num_literal);
-      if (lookahead == '.') ADVANCE(89);
-      if (lookahead == 'b') ADVANCE(84);
-      if (lookahead == 'o') ADVANCE(86);
-      if (lookahead == 'x') ADVANCE(92);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(82);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(108);
+          lookahead == 'e') ADVANCE(80);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(107);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(sym_signed_num_literal);
-      if (lookahead == '.') ADVANCE(89);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(82);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(108);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(108);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(sym_signed_num_literal);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(82);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(109);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(109);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym_signed_num_literal);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(110);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(110);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(sym_signed_num_literal);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(111);
-      END_STATE();
-    case 112:
-      ACCEPT_TOKEN(sym_signed_num_literal);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(112);
-      END_STATE();
-    case 113:
-      ACCEPT_TOKEN(sym_signed_num_literal);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(113);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(111);
+      END_STATE();
+    case 112:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == '_') ADVANCE(128);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 113:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'a') ADVANCE(142);
+      if (lookahead == 'o') ADVANCE(167);
+      if (lookahead == 'u') ADVANCE(150);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 114:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == '_') ADVANCE(130);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 115:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(145);
-      if (lookahead == 'o') ADVANCE(171);
-      if (lookahead == 'u') ADVANCE(153);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 116:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(194);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 117:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(150);
-      if (lookahead == 'c') ADVANCE(129);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 118:
       ACCEPT_TOKEN(sym_ident);
       if (lookahead == 'a') ADVANCE(190);
       if (lookahead == '\'' ||
@@ -3855,445 +3827,475 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'a') ADVANCE(147);
+      if (lookahead == 'c') ADVANCE(127);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 116:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'a') ADVANCE(186);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 117:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'a') ADVANCE(178);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 118:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'a') ADVANCE(143);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(182);
-      if (lookahead == 'e') ADVANCE(172);
+      if (lookahead == 'b') ADVANCE(133);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'a') ADVANCE(146);
+      if (lookahead == 'c') ADVANCE(97);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'b') ADVANCE(135);
+      if (lookahead == 'c') ADVANCE(136);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'c') ADVANCE(99);
+      if (lookahead == 'c') ADVANCE(146);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'c') ADVANCE(139);
+      if (lookahead == 'd') ADVANCE(97);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'c') ADVANCE(149);
+      if (lookahead == 'd') ADVANCE(130);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'd') ADVANCE(99);
+      if (lookahead == 'e') ADVANCE(134);
+      if (lookahead == 'o') ADVANCE(120);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'd') ADVANCE(132);
+      if (lookahead == 'e') ADVANCE(120);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 127:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(136);
-      if (lookahead == 'o') ADVANCE(122);
+      if (lookahead == 'e') ADVANCE(97);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(122);
+      if (lookahead == 'e') ADVANCE(187);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(99);
+      if (lookahead == 'e') ADVANCE(123);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(191);
+      if (lookahead == 'e') ADVANCE(215);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(125);
+      if (lookahead == 'e') ADVANCE(176);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(219);
+      if (lookahead == 'e') ADVANCE(150);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(180);
+      if (lookahead == 'e') ADVANCE(168);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(153);
+      if (lookahead == 'f') ADVANCE(116);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'e') ADVANCE(173);
+      if (lookahead == 'g') ADVANCE(250);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'f') ADVANCE(118);
+      if (lookahead == 'h') ADVANCE(97);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'g') ADVANCE(254);
+      if (lookahead == 'h') ADVANCE(132);
+      if (lookahead == 'r') ADVANCE(185);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'g') ADVANCE(129);
+      if (lookahead == 'i') ADVANCE(152);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 139:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'h') ADVANCE(99);
+      if (lookahead == 'i') ADVANCE(158);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'h') ADVANCE(134);
-      if (lookahead == 'r') ADVANCE(189);
+      if (lookahead == 'i') ADVANCE(179);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 141:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'i') ADVANCE(155);
+      if (lookahead == 'i') ADVANCE(160);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 142:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'i') ADVANCE(161);
+      if (lookahead == 'l') ADVANCE(175);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 143:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'i') ADVANCE(183);
+      if (lookahead == 'l') ADVANCE(97);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 144:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'i') ADVANCE(163);
+      if (lookahead == 'l') ADVANCE(249);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 145:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(179);
+      if (lookahead == 'l') ADVANCE(176);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(99);
+      if (lookahead == 'l') ADVANCE(184);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 147:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(253);
+      if (lookahead == 'l') ADVANCE(143);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 148:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(180);
+      if (lookahead == 'm') ADVANCE(162);
+      if (lookahead == 'f' ||
+          lookahead == 'n') ADVANCE(97);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 149:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(188);
+      if (lookahead == 'm') ADVANCE(119);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 150:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'l') ADVANCE(146);
+      if (lookahead == 'n') ADVANCE(97);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 151:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'm') ADVANCE(165);
-      if (lookahead == 'f' ||
-          lookahead == 'n') ADVANCE(99);
+      if (lookahead == 'n') ADVANCE(208);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 152:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'm') ADVANCE(121);
+      if (lookahead == 'n') ADVANCE(135);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 153:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'n') ADVANCE(99);
+      if (lookahead == 'n') ADVANCE(122);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 154:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'n') ADVANCE(212);
+      if (lookahead == 'n') ADVANCE(118);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'n') ADVANCE(137);
+      if (lookahead == 'o') ADVANCE(156);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 156:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'n') ADVANCE(124);
+      if (lookahead == 'o') ADVANCE(144);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 157:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'n') ADVANCE(120);
+      if (lookahead == 'o') ADVANCE(177);
+      if (lookahead == 'u') ADVANCE(147);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 158:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'o') ADVANCE(159);
+      if (lookahead == 'o') ADVANCE(154);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 159:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'o') ADVANCE(147);
+      if (lookahead == 'o') ADVANCE(169);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 160:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'o') ADVANCE(181);
-      if (lookahead == 'u') ADVANCE(150);
+      if (lookahead == 'o') ADVANCE(173);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 161:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'o') ADVANCE(157);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 162:
       ACCEPT_TOKEN(sym_ident);
       if (lookahead == 'o') ADVANCE(174);
       if (lookahead == '\'' ||
@@ -4301,130 +4303,50 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 162:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'p') ADVANCE(159);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 163:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'o') ADVANCE(177);
+      if (lookahead == 'p') ADVANCE(182);
+      if (lookahead == 'r') ADVANCE(220);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 164:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'o') ADVANCE(178);
+      if (lookahead == 'p') ADVANCE(182);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 165:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'p') ADVANCE(162);
+      if (lookahead == 'p') ADVANCE(161);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 166:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'p') ADVANCE(186);
-      if (lookahead == 'r') ADVANCE(224);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 167:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'p') ADVANCE(186);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 168:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'p') ADVANCE(164);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 169:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(144);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 170:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(116);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 171:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(117);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 172:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(138);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 173:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(252);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 174:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(180);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 175:
       ACCEPT_TOKEN(sym_ident);
       if (lookahead == 'r') ADVANCE(141);
       if (lookahead == '\'' ||
@@ -4432,9 +4354,59 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
-    case 176:
+    case 167:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(115);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 168:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(248);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 169:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(176);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 170:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(114);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 171:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(138);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 172:
       ACCEPT_TOKEN(sym_ident);
       if (lookahead == 'r') ADVANCE(170);
       if (lookahead == '\'' ||
@@ -4442,474 +4414,474 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 173:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(140);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 174:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 'r') ADVANCE(181);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 175:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 's') ADVANCE(127);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
+      END_STATE();
+    case 176:
+      ACCEPT_TOKEN(sym_ident);
+      if (lookahead == 't') ADVANCE(97);
+      if (lookahead == '\'' ||
+          lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 177:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(143);
+      if (lookahead == 't') ADVANCE(112);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 178:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'r') ADVANCE(185);
+      if (lookahead == 't') ADVANCE(121);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 179:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 's') ADVANCE(129);
+      if (lookahead == 't') ADVANCE(189);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 180:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(99);
+      if (lookahead == 't') ADVANCE(171);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 181:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(114);
+      if (lookahead == 't') ADVANCE(129);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 182:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(123);
+      if (lookahead == 't') ADVANCE(139);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 183:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(193);
+      if (lookahead == 'u') ADVANCE(149);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 184:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(175);
+      if (lookahead == 'u') ADVANCE(124);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 185:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(131);
+      if (lookahead == 'u') ADVANCE(127);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 186:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 't') ADVANCE(142);
+      if (lookahead == 'u') ADVANCE(145);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 187:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'u') ADVANCE(152);
+      if (lookahead == 'x') ADVANCE(165);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'u') ADVANCE(126);
+      if (lookahead == 'y') ADVANCE(151);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 189:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'u') ADVANCE(129);
+      if (lookahead == 'y') ADVANCE(97);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 190:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'u') ADVANCE(148);
+      if (lookahead == 'y') ADVANCE(207);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 191:
       ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'x') ADVANCE(168);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
     case 192:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'y') ADVANCE(154);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 193:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'y') ADVANCE(99);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 194:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == 'y') ADVANCE(211);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 195:
-      ACCEPT_TOKEN(sym_ident);
-      if (lookahead == '\'' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
-      END_STATE();
-    case 196:
       ACCEPT_TOKEN(sym_raw_enum_tag);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(196);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(192);
+      END_STATE();
+    case 193:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      END_STATE();
+    case 194:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '>') ADVANCE(238);
+      if (lookahead == ']') ADVANCE(252);
+      if (lookahead == '|') ADVANCE(246);
+      END_STATE();
+    case 195:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '>') ADVANCE(238);
+      if (lookahead == '|') ADVANCE(246);
+      END_STATE();
+    case 196:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == ']') ADVANCE(252);
       END_STATE();
     case 197:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      END_STATE();
-    case 198:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '>') ADVANCE(242);
-      if (lookahead == ']') ADVANCE(256);
-      if (lookahead == '|') ADVANCE(250);
-      END_STATE();
-    case 199:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '>') ADVANCE(242);
-      if (lookahead == '|') ADVANCE(250);
-      END_STATE();
-    case 200:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == ']') ADVANCE(256);
-      END_STATE();
-    case 201:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 202:
+    case 198:
       ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
-    case 203:
+    case 199:
       ACCEPT_TOKEN(anon_sym_EQ);
-      if (lookahead == '=') ADVANCE(247);
-      if (lookahead == '>') ADVANCE(206);
+      if (lookahead == '=') ADVANCE(243);
+      if (lookahead == '>') ADVANCE(202);
       END_STATE();
-    case 204:
+    case 200:
       ACCEPT_TOKEN(anon_sym_EQ);
-      if (lookahead == '>') ADVANCE(206);
+      if (lookahead == '>') ADVANCE(202);
       END_STATE();
-    case 205:
+    case 201:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
-    case 206:
+    case 202:
       ACCEPT_TOKEN(anon_sym_EQ_GT);
       END_STATE();
-    case 207:
+    case 203:
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
-    case 208:
+    case 204:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 209:
+    case 205:
       ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
-    case 210:
+    case 206:
       ACCEPT_TOKEN(anon_sym_DOT);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(102);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(100);
       END_STATE();
-    case 211:
+    case 207:
       ACCEPT_TOKEN(anon_sym_Array);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
-    case 212:
+    case 208:
       ACCEPT_TOKEN(anon_sym_Dyn);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
-    case 213:
+    case 209:
       ACCEPT_TOKEN(anon_sym_SEMI);
       END_STATE();
-    case 214:
+    case 210:
       ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
-    case 215:
+    case 211:
       ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
-    case 216:
+    case 212:
       ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
-    case 217:
+    case 213:
       ACCEPT_TOKEN(anon_sym_LBRACK);
-      if (lookahead == '|') ADVANCE(255);
+      if (lookahead == '|') ADVANCE(251);
       END_STATE();
-    case 218:
+    case 214:
       ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
-    case 219:
+    case 215:
       ACCEPT_TOKEN(anon_sym_include);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
-    case 220:
+    case 216:
       ACCEPT_TOKEN(anon_sym_DOT_DOT);
       END_STATE();
-    case 221:
+    case 217:
       ACCEPT_TOKEN(anon_sym_AT);
       END_STATE();
-    case 222:
+    case 218:
       ACCEPT_TOKEN(anon_sym__);
       if (lookahead == '_') ADVANCE(23);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
-    case 223:
+    case 219:
       ACCEPT_TOKEN(anon_sym_or);
       END_STATE();
-    case 224:
+    case 220:
       ACCEPT_TOKEN(anon_sym_or);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
-    case 225:
+    case 221:
       ACCEPT_TOKEN(anon_sym_QMARK);
       END_STATE();
-    case 226:
+    case 222:
       ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
-    case 227:
+    case 223:
       ACCEPT_TOKEN(sym_double_quote);
       END_STATE();
-    case 228:
+    case 224:
       ACCEPT_TOKEN(sym_str_literal);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(228);
+          lookahead == ' ') ADVANCE(224);
       if (lookahead != 0 &&
           lookahead != '"' &&
           lookahead != '%' &&
-          lookahead != '\\') ADVANCE(229);
+          lookahead != '\\') ADVANCE(225);
+      END_STATE();
+    case 225:
+      ACCEPT_TOKEN(sym_str_literal);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '%' &&
+          lookahead != '\\') ADVANCE(225);
+      END_STATE();
+    case 226:
+      ACCEPT_TOKEN(sym_mult_str_literal);
+      if (lookahead == '\n') ADVANCE(228);
+      if (lookahead == '"' ||
+          lookahead == '%') ADVANCE(229);
+      if (lookahead != 0) ADVANCE(228);
+      END_STATE();
+    case 227:
+      ACCEPT_TOKEN(sym_mult_str_literal);
+      if (lookahead == '\\') ADVANCE(226);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(227);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '%') ADVANCE(228);
+      END_STATE();
+    case 228:
+      ACCEPT_TOKEN(sym_mult_str_literal);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '%') ADVANCE(228);
       END_STATE();
     case 229:
-      ACCEPT_TOKEN(sym_str_literal);
-      if (lookahead != 0 &&
-          lookahead != '"' &&
-          lookahead != '%' &&
-          lookahead != '\\') ADVANCE(229);
-      END_STATE();
-    case 230:
-      ACCEPT_TOKEN(sym_mult_str_literal);
-      if (lookahead == '\n') ADVANCE(232);
-      if (lookahead == '"' ||
-          lookahead == '%') ADVANCE(233);
-      if (lookahead != 0) ADVANCE(232);
-      END_STATE();
-    case 231:
-      ACCEPT_TOKEN(sym_mult_str_literal);
-      if (lookahead == '\\') ADVANCE(230);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(231);
-      if (lookahead != 0 &&
-          lookahead != '"' &&
-          lookahead != '%') ADVANCE(232);
-      END_STATE();
-    case 232:
-      ACCEPT_TOKEN(sym_mult_str_literal);
-      if (lookahead != 0 &&
-          lookahead != '"' &&
-          lookahead != '%') ADVANCE(232);
-      END_STATE();
-    case 233:
       ACCEPT_TOKEN(sym_str_esc_char);
       END_STATE();
-    case 234:
+    case 230:
       ACCEPT_TOKEN(aux_sym_builtin_token1);
       if (lookahead == '\'' ||
           ('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(234);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(230);
       END_STATE();
-    case 235:
+    case 231:
       ACCEPT_TOKEN(anon_sym_PLUS_PLUS);
       END_STATE();
-    case 236:
+    case 232:
       ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
-    case 237:
+    case 233:
       ACCEPT_TOKEN(anon_sym_SLASH);
       END_STATE();
-    case 238:
+    case 234:
       ACCEPT_TOKEN(anon_sym_PLUS);
-      if (lookahead == '+') ADVANCE(235);
+      if (lookahead == '+') ADVANCE(231);
       END_STATE();
-    case 239:
+    case 235:
       ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '>') ADVANCE(251);
+      if (lookahead == '>') ADVANCE(247);
       END_STATE();
-    case 240:
+    case 236:
       ACCEPT_TOKEN(anon_sym_BANG);
-      if (lookahead == '=') ADVANCE(248);
-      END_STATE();
-    case 241:
-      ACCEPT_TOKEN(anon_sym_AMP);
-      if (lookahead == '&') ADVANCE(249);
-      END_STATE();
-    case 242:
-      ACCEPT_TOKEN(anon_sym_PIPE_GT);
-      END_STATE();
-    case 243:
-      ACCEPT_TOKEN(anon_sym_LT);
       if (lookahead == '=') ADVANCE(244);
       END_STATE();
-    case 244:
+    case 237:
+      ACCEPT_TOKEN(anon_sym_AMP);
+      if (lookahead == '&') ADVANCE(245);
+      END_STATE();
+    case 238:
+      ACCEPT_TOKEN(anon_sym_PIPE_GT);
+      END_STATE();
+    case 239:
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '=') ADVANCE(240);
+      END_STATE();
+    case 240:
       ACCEPT_TOKEN(anon_sym_LT_EQ);
       END_STATE();
-    case 245:
+    case 241:
       ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '=') ADVANCE(246);
+      if (lookahead == '=') ADVANCE(242);
       END_STATE();
-    case 246:
+    case 242:
       ACCEPT_TOKEN(anon_sym_GT_EQ);
       END_STATE();
-    case 247:
+    case 243:
       ACCEPT_TOKEN(anon_sym_EQ_EQ);
       END_STATE();
-    case 248:
+    case 244:
       ACCEPT_TOKEN(anon_sym_BANG_EQ);
       END_STATE();
-    case 249:
+    case 245:
       ACCEPT_TOKEN(anon_sym_AMP_AMP);
       END_STATE();
-    case 250:
+    case 246:
       ACCEPT_TOKEN(anon_sym_PIPE_PIPE);
       END_STATE();
-    case 251:
+    case 247:
       ACCEPT_TOKEN(anon_sym_DASH_GT);
       END_STATE();
-    case 252:
+    case 248:
       ACCEPT_TOKEN(anon_sym_Number);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
-    case 253:
+    case 249:
       ACCEPT_TOKEN(anon_sym_Bool);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
-    case 254:
+    case 250:
       ACCEPT_TOKEN(anon_sym_String);
       if (lookahead == '\'' ||
           lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(195);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(191);
       END_STATE();
-    case 255:
+    case 251:
       ACCEPT_TOKEN(anon_sym_LBRACK_PIPE);
       END_STATE();
-    case 256:
+    case 252:
       ACCEPT_TOKEN(anon_sym_PIPE_RBRACK);
       END_STATE();
     default:
@@ -5205,512 +5177,512 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
 
 static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0, .external_lex_state = 1},
-  [1] = {.lex_state = 94, .external_lex_state = 2},
-  [2] = {.lex_state = 94, .external_lex_state = 2},
-  [3] = {.lex_state = 94, .external_lex_state = 2},
-  [4] = {.lex_state = 94, .external_lex_state = 2},
-  [5] = {.lex_state = 94, .external_lex_state = 2},
-  [6] = {.lex_state = 94, .external_lex_state = 2},
-  [7] = {.lex_state = 94, .external_lex_state = 2},
-  [8] = {.lex_state = 94, .external_lex_state = 2},
-  [9] = {.lex_state = 95, .external_lex_state = 2},
-  [10] = {.lex_state = 95, .external_lex_state = 2},
-  [11] = {.lex_state = 94, .external_lex_state = 2},
-  [12] = {.lex_state = 94, .external_lex_state = 2},
-  [13] = {.lex_state = 94, .external_lex_state = 2},
-  [14] = {.lex_state = 94, .external_lex_state = 2},
-  [15] = {.lex_state = 94, .external_lex_state = 2},
-  [16] = {.lex_state = 94, .external_lex_state = 2},
-  [17] = {.lex_state = 94, .external_lex_state = 2},
-  [18] = {.lex_state = 94, .external_lex_state = 2},
-  [19] = {.lex_state = 94, .external_lex_state = 2},
-  [20] = {.lex_state = 94, .external_lex_state = 2},
-  [21] = {.lex_state = 94, .external_lex_state = 2},
-  [22] = {.lex_state = 94, .external_lex_state = 2},
-  [23] = {.lex_state = 94, .external_lex_state = 2},
-  [24] = {.lex_state = 94, .external_lex_state = 2},
-  [25] = {.lex_state = 94, .external_lex_state = 2},
-  [26] = {.lex_state = 94, .external_lex_state = 2},
-  [27] = {.lex_state = 94, .external_lex_state = 2},
-  [28] = {.lex_state = 94, .external_lex_state = 2},
-  [29] = {.lex_state = 94, .external_lex_state = 2},
-  [30] = {.lex_state = 94, .external_lex_state = 2},
-  [31] = {.lex_state = 94, .external_lex_state = 2},
-  [32] = {.lex_state = 94, .external_lex_state = 2},
-  [33] = {.lex_state = 94, .external_lex_state = 2},
-  [34] = {.lex_state = 94, .external_lex_state = 2},
-  [35] = {.lex_state = 94, .external_lex_state = 2},
-  [36] = {.lex_state = 94, .external_lex_state = 2},
-  [37] = {.lex_state = 94, .external_lex_state = 2},
-  [38] = {.lex_state = 94, .external_lex_state = 2},
-  [39] = {.lex_state = 94, .external_lex_state = 2},
-  [40] = {.lex_state = 94, .external_lex_state = 2},
-  [41] = {.lex_state = 94, .external_lex_state = 2},
-  [42] = {.lex_state = 94, .external_lex_state = 2},
-  [43] = {.lex_state = 94, .external_lex_state = 2},
-  [44] = {.lex_state = 94, .external_lex_state = 2},
-  [45] = {.lex_state = 94, .external_lex_state = 2},
-  [46] = {.lex_state = 94, .external_lex_state = 2},
-  [47] = {.lex_state = 94, .external_lex_state = 2},
-  [48] = {.lex_state = 94, .external_lex_state = 2},
-  [49] = {.lex_state = 94, .external_lex_state = 2},
-  [50] = {.lex_state = 94, .external_lex_state = 2},
-  [51] = {.lex_state = 94, .external_lex_state = 2},
-  [52] = {.lex_state = 94, .external_lex_state = 2},
-  [53] = {.lex_state = 94, .external_lex_state = 2},
-  [54] = {.lex_state = 94, .external_lex_state = 2},
-  [55] = {.lex_state = 94, .external_lex_state = 2},
-  [56] = {.lex_state = 94, .external_lex_state = 2},
-  [57] = {.lex_state = 94, .external_lex_state = 2},
-  [58] = {.lex_state = 94, .external_lex_state = 2},
-  [59] = {.lex_state = 94, .external_lex_state = 2},
-  [60] = {.lex_state = 94, .external_lex_state = 2},
-  [61] = {.lex_state = 94, .external_lex_state = 2},
-  [62] = {.lex_state = 94, .external_lex_state = 2},
-  [63] = {.lex_state = 94, .external_lex_state = 2},
-  [64] = {.lex_state = 94, .external_lex_state = 2},
-  [65] = {.lex_state = 94, .external_lex_state = 2},
-  [66] = {.lex_state = 94, .external_lex_state = 2},
-  [67] = {.lex_state = 94, .external_lex_state = 2},
-  [68] = {.lex_state = 94, .external_lex_state = 2},
-  [69] = {.lex_state = 94, .external_lex_state = 2},
-  [70] = {.lex_state = 94, .external_lex_state = 2},
-  [71] = {.lex_state = 94, .external_lex_state = 2},
-  [72] = {.lex_state = 94, .external_lex_state = 2},
-  [73] = {.lex_state = 95, .external_lex_state = 2},
-  [74] = {.lex_state = 94, .external_lex_state = 2},
-  [75] = {.lex_state = 95, .external_lex_state = 3},
-  [76] = {.lex_state = 95, .external_lex_state = 2},
-  [77] = {.lex_state = 94, .external_lex_state = 2},
-  [78] = {.lex_state = 94, .external_lex_state = 2},
-  [79] = {.lex_state = 95, .external_lex_state = 2},
-  [80] = {.lex_state = 94, .external_lex_state = 2},
-  [81] = {.lex_state = 94, .external_lex_state = 2},
-  [82] = {.lex_state = 94, .external_lex_state = 2},
-  [83] = {.lex_state = 95, .external_lex_state = 2},
-  [84] = {.lex_state = 95, .external_lex_state = 2},
-  [85] = {.lex_state = 95, .external_lex_state = 3},
-  [86] = {.lex_state = 95, .external_lex_state = 2},
-  [87] = {.lex_state = 95, .external_lex_state = 2},
-  [88] = {.lex_state = 95, .external_lex_state = 2},
+  [1] = {.lex_state = 92, .external_lex_state = 2},
+  [2] = {.lex_state = 92, .external_lex_state = 2},
+  [3] = {.lex_state = 92, .external_lex_state = 2},
+  [4] = {.lex_state = 92, .external_lex_state = 2},
+  [5] = {.lex_state = 92, .external_lex_state = 2},
+  [6] = {.lex_state = 92, .external_lex_state = 2},
+  [7] = {.lex_state = 92, .external_lex_state = 2},
+  [8] = {.lex_state = 92, .external_lex_state = 2},
+  [9] = {.lex_state = 93, .external_lex_state = 2},
+  [10] = {.lex_state = 93, .external_lex_state = 2},
+  [11] = {.lex_state = 92, .external_lex_state = 2},
+  [12] = {.lex_state = 92, .external_lex_state = 2},
+  [13] = {.lex_state = 92, .external_lex_state = 2},
+  [14] = {.lex_state = 92, .external_lex_state = 2},
+  [15] = {.lex_state = 92, .external_lex_state = 2},
+  [16] = {.lex_state = 92, .external_lex_state = 2},
+  [17] = {.lex_state = 92, .external_lex_state = 2},
+  [18] = {.lex_state = 92, .external_lex_state = 2},
+  [19] = {.lex_state = 92, .external_lex_state = 2},
+  [20] = {.lex_state = 92, .external_lex_state = 2},
+  [21] = {.lex_state = 92, .external_lex_state = 2},
+  [22] = {.lex_state = 92, .external_lex_state = 2},
+  [23] = {.lex_state = 92, .external_lex_state = 2},
+  [24] = {.lex_state = 92, .external_lex_state = 2},
+  [25] = {.lex_state = 92, .external_lex_state = 2},
+  [26] = {.lex_state = 92, .external_lex_state = 2},
+  [27] = {.lex_state = 92, .external_lex_state = 2},
+  [28] = {.lex_state = 92, .external_lex_state = 2},
+  [29] = {.lex_state = 92, .external_lex_state = 2},
+  [30] = {.lex_state = 92, .external_lex_state = 2},
+  [31] = {.lex_state = 92, .external_lex_state = 2},
+  [32] = {.lex_state = 92, .external_lex_state = 2},
+  [33] = {.lex_state = 92, .external_lex_state = 2},
+  [34] = {.lex_state = 92, .external_lex_state = 2},
+  [35] = {.lex_state = 92, .external_lex_state = 2},
+  [36] = {.lex_state = 92, .external_lex_state = 2},
+  [37] = {.lex_state = 92, .external_lex_state = 2},
+  [38] = {.lex_state = 92, .external_lex_state = 2},
+  [39] = {.lex_state = 92, .external_lex_state = 2},
+  [40] = {.lex_state = 92, .external_lex_state = 2},
+  [41] = {.lex_state = 92, .external_lex_state = 2},
+  [42] = {.lex_state = 92, .external_lex_state = 2},
+  [43] = {.lex_state = 92, .external_lex_state = 2},
+  [44] = {.lex_state = 92, .external_lex_state = 2},
+  [45] = {.lex_state = 92, .external_lex_state = 2},
+  [46] = {.lex_state = 92, .external_lex_state = 2},
+  [47] = {.lex_state = 92, .external_lex_state = 2},
+  [48] = {.lex_state = 92, .external_lex_state = 2},
+  [49] = {.lex_state = 92, .external_lex_state = 2},
+  [50] = {.lex_state = 92, .external_lex_state = 2},
+  [51] = {.lex_state = 92, .external_lex_state = 2},
+  [52] = {.lex_state = 92, .external_lex_state = 2},
+  [53] = {.lex_state = 92, .external_lex_state = 2},
+  [54] = {.lex_state = 92, .external_lex_state = 2},
+  [55] = {.lex_state = 92, .external_lex_state = 2},
+  [56] = {.lex_state = 92, .external_lex_state = 2},
+  [57] = {.lex_state = 92, .external_lex_state = 2},
+  [58] = {.lex_state = 92, .external_lex_state = 2},
+  [59] = {.lex_state = 92, .external_lex_state = 2},
+  [60] = {.lex_state = 92, .external_lex_state = 2},
+  [61] = {.lex_state = 92, .external_lex_state = 2},
+  [62] = {.lex_state = 92, .external_lex_state = 2},
+  [63] = {.lex_state = 92, .external_lex_state = 2},
+  [64] = {.lex_state = 92, .external_lex_state = 2},
+  [65] = {.lex_state = 92, .external_lex_state = 2},
+  [66] = {.lex_state = 92, .external_lex_state = 2},
+  [67] = {.lex_state = 92, .external_lex_state = 2},
+  [68] = {.lex_state = 92, .external_lex_state = 2},
+  [69] = {.lex_state = 92, .external_lex_state = 2},
+  [70] = {.lex_state = 92, .external_lex_state = 2},
+  [71] = {.lex_state = 92, .external_lex_state = 2},
+  [72] = {.lex_state = 92, .external_lex_state = 2},
+  [73] = {.lex_state = 93, .external_lex_state = 2},
+  [74] = {.lex_state = 92, .external_lex_state = 2},
+  [75] = {.lex_state = 93, .external_lex_state = 3},
+  [76] = {.lex_state = 93, .external_lex_state = 2},
+  [77] = {.lex_state = 92, .external_lex_state = 2},
+  [78] = {.lex_state = 92, .external_lex_state = 2},
+  [79] = {.lex_state = 93, .external_lex_state = 2},
+  [80] = {.lex_state = 92, .external_lex_state = 2},
+  [81] = {.lex_state = 92, .external_lex_state = 2},
+  [82] = {.lex_state = 92, .external_lex_state = 2},
+  [83] = {.lex_state = 93, .external_lex_state = 2},
+  [84] = {.lex_state = 93, .external_lex_state = 2},
+  [85] = {.lex_state = 93, .external_lex_state = 3},
+  [86] = {.lex_state = 93, .external_lex_state = 2},
+  [87] = {.lex_state = 93, .external_lex_state = 2},
+  [88] = {.lex_state = 93, .external_lex_state = 2},
   [89] = {.lex_state = 1, .external_lex_state = 2},
   [90] = {.lex_state = 1, .external_lex_state = 2},
   [91] = {.lex_state = 1, .external_lex_state = 2},
-  [92] = {.lex_state = 95, .external_lex_state = 2},
-  [93] = {.lex_state = 95, .external_lex_state = 2},
-  [94] = {.lex_state = 95, .external_lex_state = 2},
-  [95] = {.lex_state = 95, .external_lex_state = 2},
-  [96] = {.lex_state = 95, .external_lex_state = 2},
-  [97] = {.lex_state = 95, .external_lex_state = 2},
-  [98] = {.lex_state = 95, .external_lex_state = 2},
-  [99] = {.lex_state = 95, .external_lex_state = 2},
-  [100] = {.lex_state = 95, .external_lex_state = 2},
-  [101] = {.lex_state = 95, .external_lex_state = 2},
-  [102] = {.lex_state = 95, .external_lex_state = 2},
-  [103] = {.lex_state = 95, .external_lex_state = 2},
-  [104] = {.lex_state = 95, .external_lex_state = 2},
-  [105] = {.lex_state = 95, .external_lex_state = 2},
-  [106] = {.lex_state = 95, .external_lex_state = 2},
-  [107] = {.lex_state = 95, .external_lex_state = 2},
-  [108] = {.lex_state = 95, .external_lex_state = 2},
-  [109] = {.lex_state = 95, .external_lex_state = 2},
-  [110] = {.lex_state = 95, .external_lex_state = 2},
-  [111] = {.lex_state = 95, .external_lex_state = 2},
-  [112] = {.lex_state = 95, .external_lex_state = 2},
-  [113] = {.lex_state = 95, .external_lex_state = 2},
-  [114] = {.lex_state = 95, .external_lex_state = 2},
-  [115] = {.lex_state = 95, .external_lex_state = 2},
-  [116] = {.lex_state = 95, .external_lex_state = 2},
-  [117] = {.lex_state = 95, .external_lex_state = 2},
-  [118] = {.lex_state = 95, .external_lex_state = 2},
-  [119] = {.lex_state = 95, .external_lex_state = 2},
-  [120] = {.lex_state = 95, .external_lex_state = 2},
-  [121] = {.lex_state = 95, .external_lex_state = 2},
-  [122] = {.lex_state = 95, .external_lex_state = 2},
-  [123] = {.lex_state = 95, .external_lex_state = 2},
-  [124] = {.lex_state = 95, .external_lex_state = 2},
-  [125] = {.lex_state = 95, .external_lex_state = 2},
-  [126] = {.lex_state = 95, .external_lex_state = 2},
-  [127] = {.lex_state = 95, .external_lex_state = 2},
-  [128] = {.lex_state = 95, .external_lex_state = 2},
-  [129] = {.lex_state = 95, .external_lex_state = 2},
-  [130] = {.lex_state = 95, .external_lex_state = 2},
-  [131] = {.lex_state = 94, .external_lex_state = 2},
-  [132] = {.lex_state = 95, .external_lex_state = 2},
-  [133] = {.lex_state = 95, .external_lex_state = 2},
-  [134] = {.lex_state = 94, .external_lex_state = 2},
-  [135] = {.lex_state = 95, .external_lex_state = 2},
-  [136] = {.lex_state = 94, .external_lex_state = 2},
-  [137] = {.lex_state = 95, .external_lex_state = 2},
-  [138] = {.lex_state = 94, .external_lex_state = 2},
-  [139] = {.lex_state = 94, .external_lex_state = 2},
-  [140] = {.lex_state = 94, .external_lex_state = 2},
-  [141] = {.lex_state = 94, .external_lex_state = 2},
-  [142] = {.lex_state = 94, .external_lex_state = 2},
-  [143] = {.lex_state = 94, .external_lex_state = 2},
-  [144] = {.lex_state = 94, .external_lex_state = 2},
-  [145] = {.lex_state = 95, .external_lex_state = 2},
-  [146] = {.lex_state = 94, .external_lex_state = 2},
-  [147] = {.lex_state = 94, .external_lex_state = 2},
-  [148] = {.lex_state = 94, .external_lex_state = 2},
-  [149] = {.lex_state = 95, .external_lex_state = 2},
-  [150] = {.lex_state = 94, .external_lex_state = 2},
-  [151] = {.lex_state = 94, .external_lex_state = 2},
-  [152] = {.lex_state = 94, .external_lex_state = 2},
-  [153] = {.lex_state = 94, .external_lex_state = 2},
-  [154] = {.lex_state = 94, .external_lex_state = 2},
-  [155] = {.lex_state = 94, .external_lex_state = 2},
-  [156] = {.lex_state = 95, .external_lex_state = 2},
-  [157] = {.lex_state = 95, .external_lex_state = 2},
-  [158] = {.lex_state = 94, .external_lex_state = 2},
-  [159] = {.lex_state = 94, .external_lex_state = 2},
-  [160] = {.lex_state = 94, .external_lex_state = 2},
-  [161] = {.lex_state = 94, .external_lex_state = 2},
-  [162] = {.lex_state = 94, .external_lex_state = 2},
-  [163] = {.lex_state = 94, .external_lex_state = 2},
-  [164] = {.lex_state = 94, .external_lex_state = 2},
-  [165] = {.lex_state = 94, .external_lex_state = 2},
-  [166] = {.lex_state = 94, .external_lex_state = 2},
-  [167] = {.lex_state = 94, .external_lex_state = 2},
-  [168] = {.lex_state = 94, .external_lex_state = 2},
-  [169] = {.lex_state = 94, .external_lex_state = 2},
-  [170] = {.lex_state = 94, .external_lex_state = 2},
-  [171] = {.lex_state = 94, .external_lex_state = 2},
-  [172] = {.lex_state = 94, .external_lex_state = 2},
-  [173] = {.lex_state = 94, .external_lex_state = 2},
-  [174] = {.lex_state = 94, .external_lex_state = 2},
-  [175] = {.lex_state = 94, .external_lex_state = 2},
-  [176] = {.lex_state = 94, .external_lex_state = 2},
-  [177] = {.lex_state = 94, .external_lex_state = 2},
-  [178] = {.lex_state = 94, .external_lex_state = 2},
-  [179] = {.lex_state = 94, .external_lex_state = 2},
-  [180] = {.lex_state = 94, .external_lex_state = 2},
-  [181] = {.lex_state = 94, .external_lex_state = 2},
-  [182] = {.lex_state = 94, .external_lex_state = 2},
-  [183] = {.lex_state = 94, .external_lex_state = 2},
-  [184] = {.lex_state = 94, .external_lex_state = 2},
-  [185] = {.lex_state = 94, .external_lex_state = 2},
-  [186] = {.lex_state = 94, .external_lex_state = 2},
-  [187] = {.lex_state = 94, .external_lex_state = 2},
-  [188] = {.lex_state = 94, .external_lex_state = 2},
-  [189] = {.lex_state = 94, .external_lex_state = 2},
-  [190] = {.lex_state = 94, .external_lex_state = 2},
-  [191] = {.lex_state = 94, .external_lex_state = 2},
-  [192] = {.lex_state = 94, .external_lex_state = 2},
-  [193] = {.lex_state = 94, .external_lex_state = 2},
-  [194] = {.lex_state = 94, .external_lex_state = 2},
-  [195] = {.lex_state = 94, .external_lex_state = 2},
-  [196] = {.lex_state = 94, .external_lex_state = 2},
-  [197] = {.lex_state = 94, .external_lex_state = 2},
-  [198] = {.lex_state = 94, .external_lex_state = 2},
-  [199] = {.lex_state = 94, .external_lex_state = 2},
-  [200] = {.lex_state = 94, .external_lex_state = 2},
-  [201] = {.lex_state = 94, .external_lex_state = 2},
-  [202] = {.lex_state = 94, .external_lex_state = 2},
-  [203] = {.lex_state = 94, .external_lex_state = 2},
-  [204] = {.lex_state = 94, .external_lex_state = 2},
-  [205] = {.lex_state = 94, .external_lex_state = 2},
-  [206] = {.lex_state = 94, .external_lex_state = 2},
-  [207] = {.lex_state = 94, .external_lex_state = 2},
-  [208] = {.lex_state = 94, .external_lex_state = 2},
-  [209] = {.lex_state = 94, .external_lex_state = 2},
-  [210] = {.lex_state = 94, .external_lex_state = 2},
-  [211] = {.lex_state = 94, .external_lex_state = 2},
-  [212] = {.lex_state = 94, .external_lex_state = 2},
-  [213] = {.lex_state = 94, .external_lex_state = 2},
-  [214] = {.lex_state = 94, .external_lex_state = 2},
-  [215] = {.lex_state = 94, .external_lex_state = 2},
-  [216] = {.lex_state = 94, .external_lex_state = 2},
-  [217] = {.lex_state = 94, .external_lex_state = 2},
-  [218] = {.lex_state = 94, .external_lex_state = 2},
-  [219] = {.lex_state = 94, .external_lex_state = 2},
-  [220] = {.lex_state = 94, .external_lex_state = 2},
-  [221] = {.lex_state = 94, .external_lex_state = 2},
-  [222] = {.lex_state = 94, .external_lex_state = 2},
-  [223] = {.lex_state = 94, .external_lex_state = 2},
-  [224] = {.lex_state = 94, .external_lex_state = 2},
-  [225] = {.lex_state = 94, .external_lex_state = 2},
-  [226] = {.lex_state = 95, .external_lex_state = 2},
-  [227] = {.lex_state = 95, .external_lex_state = 2},
-  [228] = {.lex_state = 95, .external_lex_state = 2},
-  [229] = {.lex_state = 95, .external_lex_state = 2},
-  [230] = {.lex_state = 95, .external_lex_state = 2},
-  [231] = {.lex_state = 95, .external_lex_state = 2},
-  [232] = {.lex_state = 95, .external_lex_state = 2},
-  [233] = {.lex_state = 95, .external_lex_state = 2},
-  [234] = {.lex_state = 95, .external_lex_state = 2},
-  [235] = {.lex_state = 95, .external_lex_state = 2},
-  [236] = {.lex_state = 95, .external_lex_state = 2},
-  [237] = {.lex_state = 95, .external_lex_state = 2},
-  [238] = {.lex_state = 95, .external_lex_state = 2},
-  [239] = {.lex_state = 95, .external_lex_state = 2},
-  [240] = {.lex_state = 95, .external_lex_state = 2},
-  [241] = {.lex_state = 95, .external_lex_state = 2},
-  [242] = {.lex_state = 95, .external_lex_state = 2},
-  [243] = {.lex_state = 95, .external_lex_state = 2},
-  [244] = {.lex_state = 95, .external_lex_state = 2},
-  [245] = {.lex_state = 95, .external_lex_state = 2},
-  [246] = {.lex_state = 95, .external_lex_state = 2},
-  [247] = {.lex_state = 95, .external_lex_state = 2},
-  [248] = {.lex_state = 95, .external_lex_state = 2},
-  [249] = {.lex_state = 95, .external_lex_state = 2},
-  [250] = {.lex_state = 95, .external_lex_state = 2},
-  [251] = {.lex_state = 95, .external_lex_state = 2},
-  [252] = {.lex_state = 95, .external_lex_state = 2},
-  [253] = {.lex_state = 95, .external_lex_state = 2},
-  [254] = {.lex_state = 95, .external_lex_state = 2},
-  [255] = {.lex_state = 95, .external_lex_state = 2},
-  [256] = {.lex_state = 95, .external_lex_state = 2},
-  [257] = {.lex_state = 95, .external_lex_state = 2},
-  [258] = {.lex_state = 95, .external_lex_state = 2},
-  [259] = {.lex_state = 95, .external_lex_state = 2},
-  [260] = {.lex_state = 95, .external_lex_state = 2},
-  [261] = {.lex_state = 95, .external_lex_state = 2},
-  [262] = {.lex_state = 95, .external_lex_state = 2},
-  [263] = {.lex_state = 95, .external_lex_state = 2},
-  [264] = {.lex_state = 95, .external_lex_state = 2},
-  [265] = {.lex_state = 95, .external_lex_state = 2},
-  [266] = {.lex_state = 95, .external_lex_state = 2},
-  [267] = {.lex_state = 95, .external_lex_state = 2},
-  [268] = {.lex_state = 95, .external_lex_state = 2},
-  [269] = {.lex_state = 95, .external_lex_state = 3},
-  [270] = {.lex_state = 95, .external_lex_state = 3},
-  [271] = {.lex_state = 95, .external_lex_state = 3},
-  [272] = {.lex_state = 95, .external_lex_state = 3},
-  [273] = {.lex_state = 95, .external_lex_state = 3},
-  [274] = {.lex_state = 95, .external_lex_state = 3},
-  [275] = {.lex_state = 95, .external_lex_state = 2},
-  [276] = {.lex_state = 95, .external_lex_state = 2},
-  [277] = {.lex_state = 95, .external_lex_state = 2},
-  [278] = {.lex_state = 95, .external_lex_state = 2},
-  [279] = {.lex_state = 95, .external_lex_state = 3},
-  [280] = {.lex_state = 95, .external_lex_state = 3},
-  [281] = {.lex_state = 95, .external_lex_state = 2},
-  [282] = {.lex_state = 95, .external_lex_state = 2},
-  [283] = {.lex_state = 95, .external_lex_state = 3},
-  [284] = {.lex_state = 95, .external_lex_state = 3},
-  [285] = {.lex_state = 95, .external_lex_state = 2},
-  [286] = {.lex_state = 95, .external_lex_state = 2},
-  [287] = {.lex_state = 95, .external_lex_state = 3},
-  [288] = {.lex_state = 95, .external_lex_state = 3},
-  [289] = {.lex_state = 95, .external_lex_state = 3},
-  [290] = {.lex_state = 95, .external_lex_state = 2},
-  [291] = {.lex_state = 95, .external_lex_state = 2},
-  [292] = {.lex_state = 95, .external_lex_state = 2},
-  [293] = {.lex_state = 95, .external_lex_state = 2},
-  [294] = {.lex_state = 95, .external_lex_state = 2},
-  [295] = {.lex_state = 95, .external_lex_state = 2},
-  [296] = {.lex_state = 95, .external_lex_state = 3},
-  [297] = {.lex_state = 95, .external_lex_state = 3},
-  [298] = {.lex_state = 95, .external_lex_state = 2},
-  [299] = {.lex_state = 95, .external_lex_state = 2},
-  [300] = {.lex_state = 95, .external_lex_state = 2},
-  [301] = {.lex_state = 95, .external_lex_state = 2},
-  [302] = {.lex_state = 95, .external_lex_state = 2},
-  [303] = {.lex_state = 95, .external_lex_state = 2},
-  [304] = {.lex_state = 95, .external_lex_state = 2},
-  [305] = {.lex_state = 95, .external_lex_state = 2},
-  [306] = {.lex_state = 95, .external_lex_state = 2},
-  [307] = {.lex_state = 95, .external_lex_state = 3},
-  [308] = {.lex_state = 95, .external_lex_state = 3},
-  [309] = {.lex_state = 95, .external_lex_state = 2},
-  [310] = {.lex_state = 95, .external_lex_state = 2},
-  [311] = {.lex_state = 95, .external_lex_state = 3},
-  [312] = {.lex_state = 95, .external_lex_state = 2},
-  [313] = {.lex_state = 95, .external_lex_state = 2},
-  [314] = {.lex_state = 95, .external_lex_state = 2},
-  [315] = {.lex_state = 95, .external_lex_state = 2},
-  [316] = {.lex_state = 95, .external_lex_state = 2},
-  [317] = {.lex_state = 95, .external_lex_state = 2},
-  [318] = {.lex_state = 95, .external_lex_state = 3},
-  [319] = {.lex_state = 95, .external_lex_state = 2},
-  [320] = {.lex_state = 95, .external_lex_state = 2},
-  [321] = {.lex_state = 95, .external_lex_state = 2},
-  [322] = {.lex_state = 95, .external_lex_state = 2},
-  [323] = {.lex_state = 95, .external_lex_state = 2},
-  [324] = {.lex_state = 95, .external_lex_state = 2},
-  [325] = {.lex_state = 95, .external_lex_state = 2},
-  [326] = {.lex_state = 95, .external_lex_state = 3},
-  [327] = {.lex_state = 95, .external_lex_state = 2},
-  [328] = {.lex_state = 95, .external_lex_state = 2},
-  [329] = {.lex_state = 95, .external_lex_state = 2},
-  [330] = {.lex_state = 95, .external_lex_state = 3},
-  [331] = {.lex_state = 95, .external_lex_state = 3},
-  [332] = {.lex_state = 95, .external_lex_state = 2},
-  [333] = {.lex_state = 95, .external_lex_state = 3},
-  [334] = {.lex_state = 95, .external_lex_state = 3},
-  [335] = {.lex_state = 95, .external_lex_state = 3},
-  [336] = {.lex_state = 95, .external_lex_state = 3},
-  [337] = {.lex_state = 95, .external_lex_state = 3},
-  [338] = {.lex_state = 95, .external_lex_state = 3},
-  [339] = {.lex_state = 95, .external_lex_state = 3},
-  [340] = {.lex_state = 95, .external_lex_state = 3},
-  [341] = {.lex_state = 95, .external_lex_state = 3},
-  [342] = {.lex_state = 95, .external_lex_state = 3},
-  [343] = {.lex_state = 95, .external_lex_state = 3},
-  [344] = {.lex_state = 95, .external_lex_state = 2},
-  [345] = {.lex_state = 95, .external_lex_state = 2},
-  [346] = {.lex_state = 95, .external_lex_state = 2},
-  [347] = {.lex_state = 95, .external_lex_state = 3},
-  [348] = {.lex_state = 95, .external_lex_state = 2},
-  [349] = {.lex_state = 95, .external_lex_state = 2},
-  [350] = {.lex_state = 95, .external_lex_state = 2},
-  [351] = {.lex_state = 95, .external_lex_state = 2},
-  [352] = {.lex_state = 95, .external_lex_state = 2},
-  [353] = {.lex_state = 95, .external_lex_state = 2},
-  [354] = {.lex_state = 95, .external_lex_state = 2},
-  [355] = {.lex_state = 95, .external_lex_state = 2},
-  [356] = {.lex_state = 95, .external_lex_state = 2},
-  [357] = {.lex_state = 95, .external_lex_state = 2},
-  [358] = {.lex_state = 95, .external_lex_state = 2},
-  [359] = {.lex_state = 95, .external_lex_state = 2},
-  [360] = {.lex_state = 95, .external_lex_state = 2},
-  [361] = {.lex_state = 95, .external_lex_state = 2},
-  [362] = {.lex_state = 95, .external_lex_state = 2},
-  [363] = {.lex_state = 95, .external_lex_state = 2},
-  [364] = {.lex_state = 95, .external_lex_state = 2},
-  [365] = {.lex_state = 95, .external_lex_state = 2},
-  [366] = {.lex_state = 95, .external_lex_state = 2},
-  [367] = {.lex_state = 95, .external_lex_state = 2},
-  [368] = {.lex_state = 95, .external_lex_state = 2},
-  [369] = {.lex_state = 95, .external_lex_state = 2},
-  [370] = {.lex_state = 95, .external_lex_state = 2},
-  [371] = {.lex_state = 95, .external_lex_state = 2},
-  [372] = {.lex_state = 95, .external_lex_state = 2},
-  [373] = {.lex_state = 95, .external_lex_state = 2},
-  [374] = {.lex_state = 95, .external_lex_state = 2},
-  [375] = {.lex_state = 95, .external_lex_state = 2},
-  [376] = {.lex_state = 95, .external_lex_state = 2},
-  [377] = {.lex_state = 95, .external_lex_state = 2},
-  [378] = {.lex_state = 95, .external_lex_state = 2},
-  [379] = {.lex_state = 95, .external_lex_state = 2},
-  [380] = {.lex_state = 95, .external_lex_state = 2},
-  [381] = {.lex_state = 95, .external_lex_state = 2},
-  [382] = {.lex_state = 95, .external_lex_state = 3},
-  [383] = {.lex_state = 95, .external_lex_state = 3},
-  [384] = {.lex_state = 95, .external_lex_state = 2},
-  [385] = {.lex_state = 95, .external_lex_state = 2},
-  [386] = {.lex_state = 95, .external_lex_state = 2},
-  [387] = {.lex_state = 95, .external_lex_state = 2},
-  [388] = {.lex_state = 95, .external_lex_state = 2},
-  [389] = {.lex_state = 95, .external_lex_state = 2},
-  [390] = {.lex_state = 95, .external_lex_state = 2},
-  [391] = {.lex_state = 95, .external_lex_state = 2},
-  [392] = {.lex_state = 95, .external_lex_state = 2},
-  [393] = {.lex_state = 95, .external_lex_state = 2},
-  [394] = {.lex_state = 95, .external_lex_state = 3},
-  [395] = {.lex_state = 95, .external_lex_state = 2},
-  [396] = {.lex_state = 95, .external_lex_state = 3},
-  [397] = {.lex_state = 95, .external_lex_state = 3},
-  [398] = {.lex_state = 95, .external_lex_state = 2},
-  [399] = {.lex_state = 95, .external_lex_state = 2},
-  [400] = {.lex_state = 95, .external_lex_state = 2},
-  [401] = {.lex_state = 95, .external_lex_state = 2},
-  [402] = {.lex_state = 95, .external_lex_state = 3},
-  [403] = {.lex_state = 95, .external_lex_state = 2},
-  [404] = {.lex_state = 95, .external_lex_state = 2},
-  [405] = {.lex_state = 95, .external_lex_state = 3},
-  [406] = {.lex_state = 95, .external_lex_state = 2},
-  [407] = {.lex_state = 95, .external_lex_state = 2},
-  [408] = {.lex_state = 95, .external_lex_state = 2},
-  [409] = {.lex_state = 95, .external_lex_state = 2},
-  [410] = {.lex_state = 95, .external_lex_state = 2},
-  [411] = {.lex_state = 95, .external_lex_state = 2},
-  [412] = {.lex_state = 95, .external_lex_state = 2},
-  [413] = {.lex_state = 95, .external_lex_state = 2},
-  [414] = {.lex_state = 95, .external_lex_state = 2},
-  [415] = {.lex_state = 95, .external_lex_state = 2},
-  [416] = {.lex_state = 95, .external_lex_state = 2},
-  [417] = {.lex_state = 95, .external_lex_state = 2},
-  [418] = {.lex_state = 95, .external_lex_state = 2},
-  [419] = {.lex_state = 95, .external_lex_state = 2},
-  [420] = {.lex_state = 95, .external_lex_state = 2},
-  [421] = {.lex_state = 95, .external_lex_state = 2},
-  [422] = {.lex_state = 95, .external_lex_state = 2},
-  [423] = {.lex_state = 95, .external_lex_state = 2},
-  [424] = {.lex_state = 95, .external_lex_state = 2},
-  [425] = {.lex_state = 95, .external_lex_state = 2},
-  [426] = {.lex_state = 95, .external_lex_state = 2},
-  [427] = {.lex_state = 95, .external_lex_state = 2},
-  [428] = {.lex_state = 95, .external_lex_state = 2},
-  [429] = {.lex_state = 95, .external_lex_state = 2},
-  [430] = {.lex_state = 95, .external_lex_state = 2},
-  [431] = {.lex_state = 95, .external_lex_state = 2},
-  [432] = {.lex_state = 95, .external_lex_state = 2},
-  [433] = {.lex_state = 95, .external_lex_state = 2},
-  [434] = {.lex_state = 95, .external_lex_state = 2},
-  [435] = {.lex_state = 95, .external_lex_state = 2},
-  [436] = {.lex_state = 95, .external_lex_state = 2},
-  [437] = {.lex_state = 95, .external_lex_state = 2},
-  [438] = {.lex_state = 95, .external_lex_state = 2},
-  [439] = {.lex_state = 95, .external_lex_state = 2},
-  [440] = {.lex_state = 95, .external_lex_state = 2},
-  [441] = {.lex_state = 95, .external_lex_state = 3},
-  [442] = {.lex_state = 95, .external_lex_state = 2},
-  [443] = {.lex_state = 95, .external_lex_state = 2},
-  [444] = {.lex_state = 95, .external_lex_state = 3},
-  [445] = {.lex_state = 95, .external_lex_state = 3},
-  [446] = {.lex_state = 95, .external_lex_state = 2},
-  [447] = {.lex_state = 95, .external_lex_state = 2},
-  [448] = {.lex_state = 95, .external_lex_state = 2},
-  [449] = {.lex_state = 95, .external_lex_state = 2},
-  [450] = {.lex_state = 95, .external_lex_state = 2},
-  [451] = {.lex_state = 95, .external_lex_state = 3},
-  [452] = {.lex_state = 95, .external_lex_state = 2},
-  [453] = {.lex_state = 95, .external_lex_state = 2},
-  [454] = {.lex_state = 95, .external_lex_state = 2},
-  [455] = {.lex_state = 95, .external_lex_state = 2},
-  [456] = {.lex_state = 95, .external_lex_state = 2},
-  [457] = {.lex_state = 95, .external_lex_state = 2},
-  [458] = {.lex_state = 95, .external_lex_state = 2},
-  [459] = {.lex_state = 95, .external_lex_state = 2},
-  [460] = {.lex_state = 95, .external_lex_state = 3},
-  [461] = {.lex_state = 95, .external_lex_state = 3},
-  [462] = {.lex_state = 95, .external_lex_state = 2},
-  [463] = {.lex_state = 95, .external_lex_state = 2},
-  [464] = {.lex_state = 95, .external_lex_state = 3},
-  [465] = {.lex_state = 95, .external_lex_state = 2},
-  [466] = {.lex_state = 95, .external_lex_state = 2},
-  [467] = {.lex_state = 95, .external_lex_state = 3},
-  [468] = {.lex_state = 95, .external_lex_state = 2},
-  [469] = {.lex_state = 95, .external_lex_state = 3},
-  [470] = {.lex_state = 95, .external_lex_state = 2},
-  [471] = {.lex_state = 95, .external_lex_state = 2},
-  [472] = {.lex_state = 95, .external_lex_state = 2},
-  [473] = {.lex_state = 95, .external_lex_state = 2},
-  [474] = {.lex_state = 95, .external_lex_state = 2},
-  [475] = {.lex_state = 95, .external_lex_state = 2},
-  [476] = {.lex_state = 94, .external_lex_state = 4},
-  [477] = {.lex_state = 94, .external_lex_state = 4},
-  [478] = {.lex_state = 94, .external_lex_state = 4},
-  [479] = {.lex_state = 94, .external_lex_state = 4},
-  [480] = {.lex_state = 94, .external_lex_state = 4},
-  [481] = {.lex_state = 94, .external_lex_state = 4},
-  [482] = {.lex_state = 94, .external_lex_state = 4},
-  [483] = {.lex_state = 94, .external_lex_state = 4},
-  [484] = {.lex_state = 94, .external_lex_state = 4},
-  [485] = {.lex_state = 94, .external_lex_state = 4},
-  [486] = {.lex_state = 94, .external_lex_state = 4},
-  [487] = {.lex_state = 94, .external_lex_state = 4},
-  [488] = {.lex_state = 94, .external_lex_state = 4},
+  [92] = {.lex_state = 93, .external_lex_state = 2},
+  [93] = {.lex_state = 93, .external_lex_state = 2},
+  [94] = {.lex_state = 93, .external_lex_state = 2},
+  [95] = {.lex_state = 93, .external_lex_state = 2},
+  [96] = {.lex_state = 93, .external_lex_state = 2},
+  [97] = {.lex_state = 93, .external_lex_state = 2},
+  [98] = {.lex_state = 93, .external_lex_state = 2},
+  [99] = {.lex_state = 93, .external_lex_state = 2},
+  [100] = {.lex_state = 93, .external_lex_state = 2},
+  [101] = {.lex_state = 93, .external_lex_state = 2},
+  [102] = {.lex_state = 93, .external_lex_state = 2},
+  [103] = {.lex_state = 93, .external_lex_state = 2},
+  [104] = {.lex_state = 93, .external_lex_state = 2},
+  [105] = {.lex_state = 93, .external_lex_state = 2},
+  [106] = {.lex_state = 93, .external_lex_state = 2},
+  [107] = {.lex_state = 93, .external_lex_state = 2},
+  [108] = {.lex_state = 93, .external_lex_state = 2},
+  [109] = {.lex_state = 93, .external_lex_state = 2},
+  [110] = {.lex_state = 93, .external_lex_state = 2},
+  [111] = {.lex_state = 93, .external_lex_state = 2},
+  [112] = {.lex_state = 93, .external_lex_state = 2},
+  [113] = {.lex_state = 93, .external_lex_state = 2},
+  [114] = {.lex_state = 93, .external_lex_state = 2},
+  [115] = {.lex_state = 93, .external_lex_state = 2},
+  [116] = {.lex_state = 93, .external_lex_state = 2},
+  [117] = {.lex_state = 93, .external_lex_state = 2},
+  [118] = {.lex_state = 93, .external_lex_state = 2},
+  [119] = {.lex_state = 93, .external_lex_state = 2},
+  [120] = {.lex_state = 93, .external_lex_state = 2},
+  [121] = {.lex_state = 93, .external_lex_state = 2},
+  [122] = {.lex_state = 93, .external_lex_state = 2},
+  [123] = {.lex_state = 93, .external_lex_state = 2},
+  [124] = {.lex_state = 93, .external_lex_state = 2},
+  [125] = {.lex_state = 93, .external_lex_state = 2},
+  [126] = {.lex_state = 93, .external_lex_state = 2},
+  [127] = {.lex_state = 93, .external_lex_state = 2},
+  [128] = {.lex_state = 93, .external_lex_state = 2},
+  [129] = {.lex_state = 93, .external_lex_state = 2},
+  [130] = {.lex_state = 93, .external_lex_state = 2},
+  [131] = {.lex_state = 92, .external_lex_state = 2},
+  [132] = {.lex_state = 93, .external_lex_state = 2},
+  [133] = {.lex_state = 93, .external_lex_state = 2},
+  [134] = {.lex_state = 92, .external_lex_state = 2},
+  [135] = {.lex_state = 93, .external_lex_state = 2},
+  [136] = {.lex_state = 92, .external_lex_state = 2},
+  [137] = {.lex_state = 93, .external_lex_state = 2},
+  [138] = {.lex_state = 92, .external_lex_state = 2},
+  [139] = {.lex_state = 92, .external_lex_state = 2},
+  [140] = {.lex_state = 92, .external_lex_state = 2},
+  [141] = {.lex_state = 92, .external_lex_state = 2},
+  [142] = {.lex_state = 92, .external_lex_state = 2},
+  [143] = {.lex_state = 92, .external_lex_state = 2},
+  [144] = {.lex_state = 92, .external_lex_state = 2},
+  [145] = {.lex_state = 93, .external_lex_state = 2},
+  [146] = {.lex_state = 92, .external_lex_state = 2},
+  [147] = {.lex_state = 92, .external_lex_state = 2},
+  [148] = {.lex_state = 92, .external_lex_state = 2},
+  [149] = {.lex_state = 93, .external_lex_state = 2},
+  [150] = {.lex_state = 92, .external_lex_state = 2},
+  [151] = {.lex_state = 92, .external_lex_state = 2},
+  [152] = {.lex_state = 92, .external_lex_state = 2},
+  [153] = {.lex_state = 92, .external_lex_state = 2},
+  [154] = {.lex_state = 92, .external_lex_state = 2},
+  [155] = {.lex_state = 92, .external_lex_state = 2},
+  [156] = {.lex_state = 93, .external_lex_state = 2},
+  [157] = {.lex_state = 93, .external_lex_state = 2},
+  [158] = {.lex_state = 92, .external_lex_state = 2},
+  [159] = {.lex_state = 92, .external_lex_state = 2},
+  [160] = {.lex_state = 92, .external_lex_state = 2},
+  [161] = {.lex_state = 92, .external_lex_state = 2},
+  [162] = {.lex_state = 92, .external_lex_state = 2},
+  [163] = {.lex_state = 92, .external_lex_state = 2},
+  [164] = {.lex_state = 92, .external_lex_state = 2},
+  [165] = {.lex_state = 92, .external_lex_state = 2},
+  [166] = {.lex_state = 92, .external_lex_state = 2},
+  [167] = {.lex_state = 92, .external_lex_state = 2},
+  [168] = {.lex_state = 92, .external_lex_state = 2},
+  [169] = {.lex_state = 92, .external_lex_state = 2},
+  [170] = {.lex_state = 92, .external_lex_state = 2},
+  [171] = {.lex_state = 92, .external_lex_state = 2},
+  [172] = {.lex_state = 92, .external_lex_state = 2},
+  [173] = {.lex_state = 92, .external_lex_state = 2},
+  [174] = {.lex_state = 92, .external_lex_state = 2},
+  [175] = {.lex_state = 92, .external_lex_state = 2},
+  [176] = {.lex_state = 92, .external_lex_state = 2},
+  [177] = {.lex_state = 92, .external_lex_state = 2},
+  [178] = {.lex_state = 92, .external_lex_state = 2},
+  [179] = {.lex_state = 92, .external_lex_state = 2},
+  [180] = {.lex_state = 92, .external_lex_state = 2},
+  [181] = {.lex_state = 92, .external_lex_state = 2},
+  [182] = {.lex_state = 92, .external_lex_state = 2},
+  [183] = {.lex_state = 92, .external_lex_state = 2},
+  [184] = {.lex_state = 92, .external_lex_state = 2},
+  [185] = {.lex_state = 92, .external_lex_state = 2},
+  [186] = {.lex_state = 92, .external_lex_state = 2},
+  [187] = {.lex_state = 92, .external_lex_state = 2},
+  [188] = {.lex_state = 92, .external_lex_state = 2},
+  [189] = {.lex_state = 92, .external_lex_state = 2},
+  [190] = {.lex_state = 92, .external_lex_state = 2},
+  [191] = {.lex_state = 92, .external_lex_state = 2},
+  [192] = {.lex_state = 92, .external_lex_state = 2},
+  [193] = {.lex_state = 92, .external_lex_state = 2},
+  [194] = {.lex_state = 92, .external_lex_state = 2},
+  [195] = {.lex_state = 92, .external_lex_state = 2},
+  [196] = {.lex_state = 92, .external_lex_state = 2},
+  [197] = {.lex_state = 92, .external_lex_state = 2},
+  [198] = {.lex_state = 92, .external_lex_state = 2},
+  [199] = {.lex_state = 92, .external_lex_state = 2},
+  [200] = {.lex_state = 92, .external_lex_state = 2},
+  [201] = {.lex_state = 92, .external_lex_state = 2},
+  [202] = {.lex_state = 92, .external_lex_state = 2},
+  [203] = {.lex_state = 92, .external_lex_state = 2},
+  [204] = {.lex_state = 92, .external_lex_state = 2},
+  [205] = {.lex_state = 92, .external_lex_state = 2},
+  [206] = {.lex_state = 92, .external_lex_state = 2},
+  [207] = {.lex_state = 92, .external_lex_state = 2},
+  [208] = {.lex_state = 92, .external_lex_state = 2},
+  [209] = {.lex_state = 92, .external_lex_state = 2},
+  [210] = {.lex_state = 92, .external_lex_state = 2},
+  [211] = {.lex_state = 92, .external_lex_state = 2},
+  [212] = {.lex_state = 92, .external_lex_state = 2},
+  [213] = {.lex_state = 92, .external_lex_state = 2},
+  [214] = {.lex_state = 92, .external_lex_state = 2},
+  [215] = {.lex_state = 92, .external_lex_state = 2},
+  [216] = {.lex_state = 92, .external_lex_state = 2},
+  [217] = {.lex_state = 92, .external_lex_state = 2},
+  [218] = {.lex_state = 92, .external_lex_state = 2},
+  [219] = {.lex_state = 92, .external_lex_state = 2},
+  [220] = {.lex_state = 92, .external_lex_state = 2},
+  [221] = {.lex_state = 92, .external_lex_state = 2},
+  [222] = {.lex_state = 92, .external_lex_state = 2},
+  [223] = {.lex_state = 92, .external_lex_state = 2},
+  [224] = {.lex_state = 92, .external_lex_state = 2},
+  [225] = {.lex_state = 92, .external_lex_state = 2},
+  [226] = {.lex_state = 93, .external_lex_state = 2},
+  [227] = {.lex_state = 93, .external_lex_state = 2},
+  [228] = {.lex_state = 93, .external_lex_state = 2},
+  [229] = {.lex_state = 93, .external_lex_state = 2},
+  [230] = {.lex_state = 93, .external_lex_state = 2},
+  [231] = {.lex_state = 93, .external_lex_state = 2},
+  [232] = {.lex_state = 93, .external_lex_state = 2},
+  [233] = {.lex_state = 93, .external_lex_state = 2},
+  [234] = {.lex_state = 93, .external_lex_state = 2},
+  [235] = {.lex_state = 93, .external_lex_state = 2},
+  [236] = {.lex_state = 93, .external_lex_state = 2},
+  [237] = {.lex_state = 93, .external_lex_state = 2},
+  [238] = {.lex_state = 93, .external_lex_state = 2},
+  [239] = {.lex_state = 93, .external_lex_state = 2},
+  [240] = {.lex_state = 93, .external_lex_state = 2},
+  [241] = {.lex_state = 93, .external_lex_state = 2},
+  [242] = {.lex_state = 93, .external_lex_state = 2},
+  [243] = {.lex_state = 93, .external_lex_state = 2},
+  [244] = {.lex_state = 93, .external_lex_state = 2},
+  [245] = {.lex_state = 93, .external_lex_state = 2},
+  [246] = {.lex_state = 93, .external_lex_state = 2},
+  [247] = {.lex_state = 93, .external_lex_state = 2},
+  [248] = {.lex_state = 93, .external_lex_state = 2},
+  [249] = {.lex_state = 93, .external_lex_state = 2},
+  [250] = {.lex_state = 93, .external_lex_state = 2},
+  [251] = {.lex_state = 93, .external_lex_state = 2},
+  [252] = {.lex_state = 93, .external_lex_state = 2},
+  [253] = {.lex_state = 93, .external_lex_state = 2},
+  [254] = {.lex_state = 93, .external_lex_state = 2},
+  [255] = {.lex_state = 93, .external_lex_state = 2},
+  [256] = {.lex_state = 93, .external_lex_state = 2},
+  [257] = {.lex_state = 93, .external_lex_state = 2},
+  [258] = {.lex_state = 93, .external_lex_state = 2},
+  [259] = {.lex_state = 93, .external_lex_state = 2},
+  [260] = {.lex_state = 93, .external_lex_state = 2},
+  [261] = {.lex_state = 93, .external_lex_state = 2},
+  [262] = {.lex_state = 93, .external_lex_state = 2},
+  [263] = {.lex_state = 93, .external_lex_state = 2},
+  [264] = {.lex_state = 93, .external_lex_state = 2},
+  [265] = {.lex_state = 93, .external_lex_state = 2},
+  [266] = {.lex_state = 93, .external_lex_state = 2},
+  [267] = {.lex_state = 93, .external_lex_state = 2},
+  [268] = {.lex_state = 93, .external_lex_state = 2},
+  [269] = {.lex_state = 93, .external_lex_state = 3},
+  [270] = {.lex_state = 93, .external_lex_state = 3},
+  [271] = {.lex_state = 93, .external_lex_state = 3},
+  [272] = {.lex_state = 93, .external_lex_state = 3},
+  [273] = {.lex_state = 93, .external_lex_state = 3},
+  [274] = {.lex_state = 93, .external_lex_state = 3},
+  [275] = {.lex_state = 93, .external_lex_state = 2},
+  [276] = {.lex_state = 93, .external_lex_state = 2},
+  [277] = {.lex_state = 93, .external_lex_state = 2},
+  [278] = {.lex_state = 93, .external_lex_state = 2},
+  [279] = {.lex_state = 93, .external_lex_state = 3},
+  [280] = {.lex_state = 93, .external_lex_state = 3},
+  [281] = {.lex_state = 93, .external_lex_state = 2},
+  [282] = {.lex_state = 93, .external_lex_state = 2},
+  [283] = {.lex_state = 93, .external_lex_state = 3},
+  [284] = {.lex_state = 93, .external_lex_state = 3},
+  [285] = {.lex_state = 93, .external_lex_state = 2},
+  [286] = {.lex_state = 93, .external_lex_state = 2},
+  [287] = {.lex_state = 93, .external_lex_state = 3},
+  [288] = {.lex_state = 93, .external_lex_state = 3},
+  [289] = {.lex_state = 93, .external_lex_state = 3},
+  [290] = {.lex_state = 93, .external_lex_state = 2},
+  [291] = {.lex_state = 93, .external_lex_state = 2},
+  [292] = {.lex_state = 93, .external_lex_state = 2},
+  [293] = {.lex_state = 93, .external_lex_state = 2},
+  [294] = {.lex_state = 93, .external_lex_state = 2},
+  [295] = {.lex_state = 93, .external_lex_state = 2},
+  [296] = {.lex_state = 93, .external_lex_state = 3},
+  [297] = {.lex_state = 93, .external_lex_state = 3},
+  [298] = {.lex_state = 93, .external_lex_state = 2},
+  [299] = {.lex_state = 93, .external_lex_state = 2},
+  [300] = {.lex_state = 93, .external_lex_state = 2},
+  [301] = {.lex_state = 93, .external_lex_state = 2},
+  [302] = {.lex_state = 93, .external_lex_state = 2},
+  [303] = {.lex_state = 93, .external_lex_state = 2},
+  [304] = {.lex_state = 93, .external_lex_state = 2},
+  [305] = {.lex_state = 93, .external_lex_state = 2},
+  [306] = {.lex_state = 93, .external_lex_state = 2},
+  [307] = {.lex_state = 93, .external_lex_state = 3},
+  [308] = {.lex_state = 93, .external_lex_state = 3},
+  [309] = {.lex_state = 93, .external_lex_state = 2},
+  [310] = {.lex_state = 93, .external_lex_state = 2},
+  [311] = {.lex_state = 93, .external_lex_state = 3},
+  [312] = {.lex_state = 93, .external_lex_state = 2},
+  [313] = {.lex_state = 93, .external_lex_state = 2},
+  [314] = {.lex_state = 93, .external_lex_state = 2},
+  [315] = {.lex_state = 93, .external_lex_state = 2},
+  [316] = {.lex_state = 93, .external_lex_state = 2},
+  [317] = {.lex_state = 93, .external_lex_state = 2},
+  [318] = {.lex_state = 93, .external_lex_state = 3},
+  [319] = {.lex_state = 93, .external_lex_state = 2},
+  [320] = {.lex_state = 93, .external_lex_state = 2},
+  [321] = {.lex_state = 93, .external_lex_state = 2},
+  [322] = {.lex_state = 93, .external_lex_state = 2},
+  [323] = {.lex_state = 93, .external_lex_state = 2},
+  [324] = {.lex_state = 93, .external_lex_state = 2},
+  [325] = {.lex_state = 93, .external_lex_state = 2},
+  [326] = {.lex_state = 93, .external_lex_state = 3},
+  [327] = {.lex_state = 93, .external_lex_state = 2},
+  [328] = {.lex_state = 93, .external_lex_state = 2},
+  [329] = {.lex_state = 93, .external_lex_state = 2},
+  [330] = {.lex_state = 93, .external_lex_state = 3},
+  [331] = {.lex_state = 93, .external_lex_state = 3},
+  [332] = {.lex_state = 93, .external_lex_state = 2},
+  [333] = {.lex_state = 93, .external_lex_state = 3},
+  [334] = {.lex_state = 93, .external_lex_state = 3},
+  [335] = {.lex_state = 93, .external_lex_state = 3},
+  [336] = {.lex_state = 93, .external_lex_state = 3},
+  [337] = {.lex_state = 93, .external_lex_state = 3},
+  [338] = {.lex_state = 93, .external_lex_state = 3},
+  [339] = {.lex_state = 93, .external_lex_state = 3},
+  [340] = {.lex_state = 93, .external_lex_state = 3},
+  [341] = {.lex_state = 93, .external_lex_state = 3},
+  [342] = {.lex_state = 93, .external_lex_state = 3},
+  [343] = {.lex_state = 93, .external_lex_state = 3},
+  [344] = {.lex_state = 93, .external_lex_state = 2},
+  [345] = {.lex_state = 93, .external_lex_state = 2},
+  [346] = {.lex_state = 93, .external_lex_state = 2},
+  [347] = {.lex_state = 93, .external_lex_state = 3},
+  [348] = {.lex_state = 93, .external_lex_state = 2},
+  [349] = {.lex_state = 93, .external_lex_state = 2},
+  [350] = {.lex_state = 93, .external_lex_state = 2},
+  [351] = {.lex_state = 93, .external_lex_state = 2},
+  [352] = {.lex_state = 93, .external_lex_state = 2},
+  [353] = {.lex_state = 93, .external_lex_state = 2},
+  [354] = {.lex_state = 93, .external_lex_state = 2},
+  [355] = {.lex_state = 93, .external_lex_state = 2},
+  [356] = {.lex_state = 93, .external_lex_state = 2},
+  [357] = {.lex_state = 93, .external_lex_state = 2},
+  [358] = {.lex_state = 93, .external_lex_state = 2},
+  [359] = {.lex_state = 93, .external_lex_state = 2},
+  [360] = {.lex_state = 93, .external_lex_state = 2},
+  [361] = {.lex_state = 93, .external_lex_state = 2},
+  [362] = {.lex_state = 93, .external_lex_state = 2},
+  [363] = {.lex_state = 93, .external_lex_state = 2},
+  [364] = {.lex_state = 93, .external_lex_state = 2},
+  [365] = {.lex_state = 93, .external_lex_state = 2},
+  [366] = {.lex_state = 93, .external_lex_state = 2},
+  [367] = {.lex_state = 93, .external_lex_state = 2},
+  [368] = {.lex_state = 93, .external_lex_state = 2},
+  [369] = {.lex_state = 93, .external_lex_state = 2},
+  [370] = {.lex_state = 93, .external_lex_state = 2},
+  [371] = {.lex_state = 93, .external_lex_state = 2},
+  [372] = {.lex_state = 93, .external_lex_state = 2},
+  [373] = {.lex_state = 93, .external_lex_state = 2},
+  [374] = {.lex_state = 93, .external_lex_state = 2},
+  [375] = {.lex_state = 93, .external_lex_state = 2},
+  [376] = {.lex_state = 93, .external_lex_state = 2},
+  [377] = {.lex_state = 93, .external_lex_state = 2},
+  [378] = {.lex_state = 93, .external_lex_state = 2},
+  [379] = {.lex_state = 93, .external_lex_state = 2},
+  [380] = {.lex_state = 93, .external_lex_state = 2},
+  [381] = {.lex_state = 93, .external_lex_state = 2},
+  [382] = {.lex_state = 93, .external_lex_state = 3},
+  [383] = {.lex_state = 93, .external_lex_state = 3},
+  [384] = {.lex_state = 93, .external_lex_state = 2},
+  [385] = {.lex_state = 93, .external_lex_state = 2},
+  [386] = {.lex_state = 93, .external_lex_state = 2},
+  [387] = {.lex_state = 93, .external_lex_state = 2},
+  [388] = {.lex_state = 93, .external_lex_state = 2},
+  [389] = {.lex_state = 93, .external_lex_state = 2},
+  [390] = {.lex_state = 93, .external_lex_state = 2},
+  [391] = {.lex_state = 93, .external_lex_state = 2},
+  [392] = {.lex_state = 93, .external_lex_state = 2},
+  [393] = {.lex_state = 93, .external_lex_state = 2},
+  [394] = {.lex_state = 93, .external_lex_state = 3},
+  [395] = {.lex_state = 93, .external_lex_state = 2},
+  [396] = {.lex_state = 93, .external_lex_state = 3},
+  [397] = {.lex_state = 93, .external_lex_state = 3},
+  [398] = {.lex_state = 93, .external_lex_state = 2},
+  [399] = {.lex_state = 93, .external_lex_state = 2},
+  [400] = {.lex_state = 93, .external_lex_state = 2},
+  [401] = {.lex_state = 93, .external_lex_state = 2},
+  [402] = {.lex_state = 93, .external_lex_state = 3},
+  [403] = {.lex_state = 93, .external_lex_state = 2},
+  [404] = {.lex_state = 93, .external_lex_state = 2},
+  [405] = {.lex_state = 93, .external_lex_state = 3},
+  [406] = {.lex_state = 93, .external_lex_state = 2},
+  [407] = {.lex_state = 93, .external_lex_state = 2},
+  [408] = {.lex_state = 93, .external_lex_state = 2},
+  [409] = {.lex_state = 93, .external_lex_state = 2},
+  [410] = {.lex_state = 93, .external_lex_state = 2},
+  [411] = {.lex_state = 93, .external_lex_state = 2},
+  [412] = {.lex_state = 93, .external_lex_state = 2},
+  [413] = {.lex_state = 93, .external_lex_state = 2},
+  [414] = {.lex_state = 93, .external_lex_state = 2},
+  [415] = {.lex_state = 93, .external_lex_state = 2},
+  [416] = {.lex_state = 93, .external_lex_state = 2},
+  [417] = {.lex_state = 93, .external_lex_state = 2},
+  [418] = {.lex_state = 93, .external_lex_state = 2},
+  [419] = {.lex_state = 93, .external_lex_state = 2},
+  [420] = {.lex_state = 93, .external_lex_state = 2},
+  [421] = {.lex_state = 93, .external_lex_state = 2},
+  [422] = {.lex_state = 93, .external_lex_state = 2},
+  [423] = {.lex_state = 93, .external_lex_state = 2},
+  [424] = {.lex_state = 93, .external_lex_state = 2},
+  [425] = {.lex_state = 93, .external_lex_state = 2},
+  [426] = {.lex_state = 93, .external_lex_state = 2},
+  [427] = {.lex_state = 93, .external_lex_state = 2},
+  [428] = {.lex_state = 93, .external_lex_state = 2},
+  [429] = {.lex_state = 93, .external_lex_state = 2},
+  [430] = {.lex_state = 93, .external_lex_state = 2},
+  [431] = {.lex_state = 93, .external_lex_state = 2},
+  [432] = {.lex_state = 93, .external_lex_state = 2},
+  [433] = {.lex_state = 93, .external_lex_state = 2},
+  [434] = {.lex_state = 93, .external_lex_state = 2},
+  [435] = {.lex_state = 93, .external_lex_state = 2},
+  [436] = {.lex_state = 93, .external_lex_state = 2},
+  [437] = {.lex_state = 93, .external_lex_state = 2},
+  [438] = {.lex_state = 93, .external_lex_state = 2},
+  [439] = {.lex_state = 93, .external_lex_state = 2},
+  [440] = {.lex_state = 93, .external_lex_state = 2},
+  [441] = {.lex_state = 93, .external_lex_state = 3},
+  [442] = {.lex_state = 93, .external_lex_state = 2},
+  [443] = {.lex_state = 93, .external_lex_state = 2},
+  [444] = {.lex_state = 93, .external_lex_state = 3},
+  [445] = {.lex_state = 93, .external_lex_state = 3},
+  [446] = {.lex_state = 93, .external_lex_state = 2},
+  [447] = {.lex_state = 93, .external_lex_state = 2},
+  [448] = {.lex_state = 93, .external_lex_state = 2},
+  [449] = {.lex_state = 93, .external_lex_state = 2},
+  [450] = {.lex_state = 93, .external_lex_state = 2},
+  [451] = {.lex_state = 93, .external_lex_state = 3},
+  [452] = {.lex_state = 93, .external_lex_state = 2},
+  [453] = {.lex_state = 93, .external_lex_state = 2},
+  [454] = {.lex_state = 93, .external_lex_state = 2},
+  [455] = {.lex_state = 93, .external_lex_state = 2},
+  [456] = {.lex_state = 93, .external_lex_state = 2},
+  [457] = {.lex_state = 93, .external_lex_state = 2},
+  [458] = {.lex_state = 93, .external_lex_state = 2},
+  [459] = {.lex_state = 93, .external_lex_state = 2},
+  [460] = {.lex_state = 93, .external_lex_state = 3},
+  [461] = {.lex_state = 93, .external_lex_state = 3},
+  [462] = {.lex_state = 93, .external_lex_state = 2},
+  [463] = {.lex_state = 93, .external_lex_state = 2},
+  [464] = {.lex_state = 93, .external_lex_state = 3},
+  [465] = {.lex_state = 93, .external_lex_state = 2},
+  [466] = {.lex_state = 93, .external_lex_state = 2},
+  [467] = {.lex_state = 93, .external_lex_state = 3},
+  [468] = {.lex_state = 93, .external_lex_state = 2},
+  [469] = {.lex_state = 93, .external_lex_state = 3},
+  [470] = {.lex_state = 93, .external_lex_state = 2},
+  [471] = {.lex_state = 93, .external_lex_state = 2},
+  [472] = {.lex_state = 93, .external_lex_state = 2},
+  [473] = {.lex_state = 93, .external_lex_state = 2},
+  [474] = {.lex_state = 93, .external_lex_state = 2},
+  [475] = {.lex_state = 93, .external_lex_state = 2},
+  [476] = {.lex_state = 92, .external_lex_state = 4},
+  [477] = {.lex_state = 92, .external_lex_state = 4},
+  [478] = {.lex_state = 92, .external_lex_state = 4},
+  [479] = {.lex_state = 92, .external_lex_state = 4},
+  [480] = {.lex_state = 92, .external_lex_state = 4},
+  [481] = {.lex_state = 92, .external_lex_state = 4},
+  [482] = {.lex_state = 92, .external_lex_state = 4},
+  [483] = {.lex_state = 92, .external_lex_state = 4},
+  [484] = {.lex_state = 92, .external_lex_state = 4},
+  [485] = {.lex_state = 92, .external_lex_state = 4},
+  [486] = {.lex_state = 92, .external_lex_state = 4},
+  [487] = {.lex_state = 92, .external_lex_state = 4},
+  [488] = {.lex_state = 92, .external_lex_state = 4},
   [489] = {.lex_state = 3, .external_lex_state = 2},
   [490] = {.lex_state = 6, .external_lex_state = 2},
   [491] = {.lex_state = 6, .external_lex_state = 2},
   [492] = {.lex_state = 6, .external_lex_state = 2},
   [493] = {.lex_state = 6, .external_lex_state = 2},
-  [494] = {.lex_state = 96, .external_lex_state = 4},
-  [495] = {.lex_state = 95, .external_lex_state = 2},
-  [496] = {.lex_state = 95, .external_lex_state = 2},
-  [497] = {.lex_state = 94, .external_lex_state = 4},
-  [498] = {.lex_state = 95, .external_lex_state = 2},
+  [494] = {.lex_state = 94, .external_lex_state = 4},
+  [495] = {.lex_state = 93, .external_lex_state = 2},
+  [496] = {.lex_state = 93, .external_lex_state = 2},
+  [497] = {.lex_state = 92, .external_lex_state = 4},
+  [498] = {.lex_state = 93, .external_lex_state = 2},
   [499] = {.lex_state = 6, .external_lex_state = 2},
-  [500] = {.lex_state = 96, .external_lex_state = 4},
-  [501] = {.lex_state = 95, .external_lex_state = 2},
+  [500] = {.lex_state = 94, .external_lex_state = 4},
+  [501] = {.lex_state = 93, .external_lex_state = 2},
   [502] = {.lex_state = 6, .external_lex_state = 2},
-  [503] = {.lex_state = 95, .external_lex_state = 2},
-  [504] = {.lex_state = 94, .external_lex_state = 5},
-  [505] = {.lex_state = 96, .external_lex_state = 4},
-  [506] = {.lex_state = 95, .external_lex_state = 2},
+  [503] = {.lex_state = 93, .external_lex_state = 2},
+  [504] = {.lex_state = 92, .external_lex_state = 5},
+  [505] = {.lex_state = 94, .external_lex_state = 4},
+  [506] = {.lex_state = 93, .external_lex_state = 2},
   [507] = {.lex_state = 6, .external_lex_state = 2},
   [508] = {.lex_state = 6, .external_lex_state = 2},
   [509] = {.lex_state = 6, .external_lex_state = 2},
@@ -5734,83 +5706,83 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [527] = {.lex_state = 6, .external_lex_state = 2},
   [528] = {.lex_state = 6, .external_lex_state = 2},
   [529] = {.lex_state = 6, .external_lex_state = 2},
-  [530] = {.lex_state = 96, .external_lex_state = 4},
-  [531] = {.lex_state = 96, .external_lex_state = 4},
-  [532] = {.lex_state = 96, .external_lex_state = 4},
-  [533] = {.lex_state = 96, .external_lex_state = 4},
-  [534] = {.lex_state = 96, .external_lex_state = 4},
+  [530] = {.lex_state = 94, .external_lex_state = 4},
+  [531] = {.lex_state = 94, .external_lex_state = 4},
+  [532] = {.lex_state = 94, .external_lex_state = 4},
+  [533] = {.lex_state = 94, .external_lex_state = 4},
+  [534] = {.lex_state = 94, .external_lex_state = 4},
   [535] = {.lex_state = 6, .external_lex_state = 2},
-  [536] = {.lex_state = 96, .external_lex_state = 4},
-  [537] = {.lex_state = 96, .external_lex_state = 4},
+  [536] = {.lex_state = 94, .external_lex_state = 4},
+  [537] = {.lex_state = 94, .external_lex_state = 4},
   [538] = {.lex_state = 6, .external_lex_state = 2},
-  [539] = {.lex_state = 96, .external_lex_state = 4},
-  [540] = {.lex_state = 96, .external_lex_state = 4},
+  [539] = {.lex_state = 94, .external_lex_state = 4},
+  [540] = {.lex_state = 94, .external_lex_state = 4},
   [541] = {.lex_state = 5, .external_lex_state = 2},
-  [542] = {.lex_state = 96, .external_lex_state = 4},
-  [543] = {.lex_state = 96, .external_lex_state = 4},
-  [544] = {.lex_state = 96, .external_lex_state = 4},
-  [545] = {.lex_state = 94, .external_lex_state = 4},
-  [546] = {.lex_state = 94, .external_lex_state = 5},
+  [542] = {.lex_state = 94, .external_lex_state = 4},
+  [543] = {.lex_state = 94, .external_lex_state = 4},
+  [544] = {.lex_state = 94, .external_lex_state = 4},
+  [545] = {.lex_state = 92, .external_lex_state = 4},
+  [546] = {.lex_state = 92, .external_lex_state = 5},
   [547] = {.lex_state = 6, .external_lex_state = 2},
-  [548] = {.lex_state = 94, .external_lex_state = 5},
-  [549] = {.lex_state = 94, .external_lex_state = 5},
-  [550] = {.lex_state = 94, .external_lex_state = 5},
-  [551] = {.lex_state = 96, .external_lex_state = 4},
-  [552] = {.lex_state = 96, .external_lex_state = 4},
-  [553] = {.lex_state = 94, .external_lex_state = 5},
-  [554] = {.lex_state = 96, .external_lex_state = 4},
-  [555] = {.lex_state = 96, .external_lex_state = 4},
-  [556] = {.lex_state = 96, .external_lex_state = 4},
-  [557] = {.lex_state = 96, .external_lex_state = 4},
-  [558] = {.lex_state = 96, .external_lex_state = 4},
-  [559] = {.lex_state = 96, .external_lex_state = 4},
-  [560] = {.lex_state = 96, .external_lex_state = 4},
-  [561] = {.lex_state = 96, .external_lex_state = 4},
-  [562] = {.lex_state = 94, .external_lex_state = 4},
-  [563] = {.lex_state = 94, .external_lex_state = 4},
-  [564] = {.lex_state = 96, .external_lex_state = 4},
-  [565] = {.lex_state = 96, .external_lex_state = 4},
-  [566] = {.lex_state = 94, .external_lex_state = 5},
-  [567] = {.lex_state = 94, .external_lex_state = 5},
+  [548] = {.lex_state = 92, .external_lex_state = 5},
+  [549] = {.lex_state = 92, .external_lex_state = 5},
+  [550] = {.lex_state = 92, .external_lex_state = 5},
+  [551] = {.lex_state = 94, .external_lex_state = 4},
+  [552] = {.lex_state = 94, .external_lex_state = 4},
+  [553] = {.lex_state = 92, .external_lex_state = 5},
+  [554] = {.lex_state = 94, .external_lex_state = 4},
+  [555] = {.lex_state = 94, .external_lex_state = 4},
+  [556] = {.lex_state = 94, .external_lex_state = 4},
+  [557] = {.lex_state = 94, .external_lex_state = 4},
+  [558] = {.lex_state = 94, .external_lex_state = 4},
+  [559] = {.lex_state = 94, .external_lex_state = 4},
+  [560] = {.lex_state = 94, .external_lex_state = 4},
+  [561] = {.lex_state = 94, .external_lex_state = 4},
+  [562] = {.lex_state = 92, .external_lex_state = 4},
+  [563] = {.lex_state = 92, .external_lex_state = 4},
+  [564] = {.lex_state = 94, .external_lex_state = 4},
+  [565] = {.lex_state = 94, .external_lex_state = 4},
+  [566] = {.lex_state = 92, .external_lex_state = 5},
+  [567] = {.lex_state = 92, .external_lex_state = 5},
   [568] = {.lex_state = 6, .external_lex_state = 2},
   [569] = {.lex_state = 6, .external_lex_state = 2},
-  [570] = {.lex_state = 94, .external_lex_state = 5},
-  [571] = {.lex_state = 96, .external_lex_state = 4},
-  [572] = {.lex_state = 96, .external_lex_state = 4},
-  [573] = {.lex_state = 96, .external_lex_state = 4},
-  [574] = {.lex_state = 96, .external_lex_state = 4},
-  [575] = {.lex_state = 96, .external_lex_state = 4},
-  [576] = {.lex_state = 96, .external_lex_state = 4},
-  [577] = {.lex_state = 96, .external_lex_state = 4},
-  [578] = {.lex_state = 96, .external_lex_state = 4},
-  [579] = {.lex_state = 96, .external_lex_state = 4},
-  [580] = {.lex_state = 96, .external_lex_state = 4},
-  [581] = {.lex_state = 94, .external_lex_state = 5},
-  [582] = {.lex_state = 96, .external_lex_state = 4},
-  [583] = {.lex_state = 94, .external_lex_state = 5},
-  [584] = {.lex_state = 94, .external_lex_state = 5},
-  [585] = {.lex_state = 94, .external_lex_state = 4},
-  [586] = {.lex_state = 94, .external_lex_state = 4},
-  [587] = {.lex_state = 94, .external_lex_state = 4},
-  [588] = {.lex_state = 94, .external_lex_state = 5},
-  [589] = {.lex_state = 94, .external_lex_state = 4},
-  [590] = {.lex_state = 94, .external_lex_state = 4},
-  [591] = {.lex_state = 94, .external_lex_state = 4},
-  [592] = {.lex_state = 94, .external_lex_state = 4},
-  [593] = {.lex_state = 94, .external_lex_state = 4},
-  [594] = {.lex_state = 94, .external_lex_state = 4},
+  [570] = {.lex_state = 92, .external_lex_state = 5},
+  [571] = {.lex_state = 94, .external_lex_state = 4},
+  [572] = {.lex_state = 94, .external_lex_state = 4},
+  [573] = {.lex_state = 94, .external_lex_state = 4},
+  [574] = {.lex_state = 94, .external_lex_state = 4},
+  [575] = {.lex_state = 94, .external_lex_state = 4},
+  [576] = {.lex_state = 94, .external_lex_state = 4},
+  [577] = {.lex_state = 94, .external_lex_state = 4},
+  [578] = {.lex_state = 94, .external_lex_state = 4},
+  [579] = {.lex_state = 94, .external_lex_state = 4},
+  [580] = {.lex_state = 94, .external_lex_state = 4},
+  [581] = {.lex_state = 92, .external_lex_state = 5},
+  [582] = {.lex_state = 94, .external_lex_state = 4},
+  [583] = {.lex_state = 92, .external_lex_state = 5},
+  [584] = {.lex_state = 92, .external_lex_state = 5},
+  [585] = {.lex_state = 92, .external_lex_state = 4},
+  [586] = {.lex_state = 92, .external_lex_state = 4},
+  [587] = {.lex_state = 92, .external_lex_state = 4},
+  [588] = {.lex_state = 92, .external_lex_state = 5},
+  [589] = {.lex_state = 92, .external_lex_state = 4},
+  [590] = {.lex_state = 92, .external_lex_state = 4},
+  [591] = {.lex_state = 92, .external_lex_state = 4},
+  [592] = {.lex_state = 92, .external_lex_state = 4},
+  [593] = {.lex_state = 92, .external_lex_state = 4},
+  [594] = {.lex_state = 92, .external_lex_state = 4},
   [595] = {.lex_state = 6, .external_lex_state = 2},
-  [596] = {.lex_state = 96, .external_lex_state = 4},
-  [597] = {.lex_state = 94, .external_lex_state = 2},
-  [598] = {.lex_state = 94, .external_lex_state = 2},
+  [596] = {.lex_state = 94, .external_lex_state = 4},
+  [597] = {.lex_state = 92, .external_lex_state = 2},
+  [598] = {.lex_state = 92, .external_lex_state = 2},
   [599] = {.lex_state = 6, .external_lex_state = 2},
-  [600] = {.lex_state = 94, .external_lex_state = 2},
-  [601] = {.lex_state = 94, .external_lex_state = 2},
+  [600] = {.lex_state = 92, .external_lex_state = 2},
+  [601] = {.lex_state = 92, .external_lex_state = 2},
   [602] = {.lex_state = 6, .external_lex_state = 2},
-  [603] = {.lex_state = 94, .external_lex_state = 2},
-  [604] = {.lex_state = 94, .external_lex_state = 2},
-  [605] = {.lex_state = 94, .external_lex_state = 2},
-  [606] = {.lex_state = 94, .external_lex_state = 2},
+  [603] = {.lex_state = 92, .external_lex_state = 2},
+  [604] = {.lex_state = 92, .external_lex_state = 2},
+  [605] = {.lex_state = 92, .external_lex_state = 2},
+  [606] = {.lex_state = 92, .external_lex_state = 2},
   [607] = {.lex_state = 6, .external_lex_state = 2},
   [608] = {.lex_state = 6, .external_lex_state = 2},
   [609] = {.lex_state = 6, .external_lex_state = 2},
@@ -5818,24 +5790,24 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [611] = {.lex_state = 6, .external_lex_state = 2},
   [612] = {.lex_state = 6, .external_lex_state = 2},
   [613] = {.lex_state = 6, .external_lex_state = 2},
-  [614] = {.lex_state = 94, .external_lex_state = 2},
+  [614] = {.lex_state = 92, .external_lex_state = 2},
   [615] = {.lex_state = 6, .external_lex_state = 2},
   [616] = {.lex_state = 6, .external_lex_state = 2},
   [617] = {.lex_state = 6, .external_lex_state = 2},
   [618] = {.lex_state = 6, .external_lex_state = 2},
   [619] = {.lex_state = 6, .external_lex_state = 2},
-  [620] = {.lex_state = 94, .external_lex_state = 2},
-  [621] = {.lex_state = 94, .external_lex_state = 2},
-  [622] = {.lex_state = 94, .external_lex_state = 2},
+  [620] = {.lex_state = 92, .external_lex_state = 2},
+  [621] = {.lex_state = 92, .external_lex_state = 2},
+  [622] = {.lex_state = 92, .external_lex_state = 2},
   [623] = {.lex_state = 6, .external_lex_state = 2},
-  [624] = {.lex_state = 94, .external_lex_state = 2},
+  [624] = {.lex_state = 92, .external_lex_state = 2},
   [625] = {.lex_state = 6, .external_lex_state = 2},
   [626] = {.lex_state = 5, .external_lex_state = 2},
-  [627] = {.lex_state = 94, .external_lex_state = 2},
-  [628] = {.lex_state = 94, .external_lex_state = 2},
-  [629] = {.lex_state = 94, .external_lex_state = 2},
+  [627] = {.lex_state = 92, .external_lex_state = 2},
+  [628] = {.lex_state = 92, .external_lex_state = 2},
+  [629] = {.lex_state = 92, .external_lex_state = 2},
   [630] = {.lex_state = 6, .external_lex_state = 2},
-  [631] = {.lex_state = 94, .external_lex_state = 2},
+  [631] = {.lex_state = 92, .external_lex_state = 2},
   [632] = {.lex_state = 6, .external_lex_state = 2},
   [633] = {.lex_state = 6, .external_lex_state = 2},
   [634] = {.lex_state = 6, .external_lex_state = 2},
@@ -5861,25 +5833,25 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [654] = {.lex_state = 15, .external_lex_state = 6},
   [655] = {.lex_state = 15, .external_lex_state = 6},
   [656] = {.lex_state = 7, .external_lex_state = 2},
-  [657] = {.lex_state = 96, .external_lex_state = 4},
-  [658] = {.lex_state = 96, .external_lex_state = 4},
+  [657] = {.lex_state = 94, .external_lex_state = 4},
+  [658] = {.lex_state = 94, .external_lex_state = 4},
   [659] = {.lex_state = 7, .external_lex_state = 2},
   [660] = {.lex_state = 7, .external_lex_state = 2},
   [661] = {.lex_state = 6, .external_lex_state = 2},
   [662] = {.lex_state = 6, .external_lex_state = 2},
   [663] = {.lex_state = 6, .external_lex_state = 2},
   [664] = {.lex_state = 6, .external_lex_state = 2},
-  [665] = {.lex_state = 96, .external_lex_state = 4},
+  [665] = {.lex_state = 94, .external_lex_state = 4},
   [666] = {.lex_state = 6, .external_lex_state = 2},
-  [667] = {.lex_state = 96, .external_lex_state = 4},
-  [668] = {.lex_state = 96, .external_lex_state = 4},
-  [669] = {.lex_state = 96, .external_lex_state = 4},
+  [667] = {.lex_state = 94, .external_lex_state = 4},
+  [668] = {.lex_state = 94, .external_lex_state = 4},
+  [669] = {.lex_state = 94, .external_lex_state = 4},
   [670] = {.lex_state = 6, .external_lex_state = 2},
-  [671] = {.lex_state = 96, .external_lex_state = 4},
-  [672] = {.lex_state = 96, .external_lex_state = 4},
+  [671] = {.lex_state = 94, .external_lex_state = 4},
+  [672] = {.lex_state = 94, .external_lex_state = 4},
   [673] = {.lex_state = 6, .external_lex_state = 2},
   [674] = {.lex_state = 6, .external_lex_state = 2},
-  [675] = {.lex_state = 96, .external_lex_state = 4},
+  [675] = {.lex_state = 94, .external_lex_state = 4},
   [676] = {.lex_state = 6, .external_lex_state = 2},
   [677] = {.lex_state = 6, .external_lex_state = 2},
   [678] = {.lex_state = 6, .external_lex_state = 2},
@@ -5899,58 +5871,58 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [692] = {.lex_state = 6, .external_lex_state = 2},
   [693] = {.lex_state = 8, .external_lex_state = 4},
   [694] = {.lex_state = 8, .external_lex_state = 4},
-  [695] = {.lex_state = 94, .external_lex_state = 4},
-  [696] = {.lex_state = 94, .external_lex_state = 4},
-  [697] = {.lex_state = 96, .external_lex_state = 4},
-  [698] = {.lex_state = 96, .external_lex_state = 4},
-  [699] = {.lex_state = 96, .external_lex_state = 4},
-  [700] = {.lex_state = 96, .external_lex_state = 4},
-  [701] = {.lex_state = 96, .external_lex_state = 4},
-  [702] = {.lex_state = 96, .external_lex_state = 4},
+  [695] = {.lex_state = 92, .external_lex_state = 4},
+  [696] = {.lex_state = 92, .external_lex_state = 4},
+  [697] = {.lex_state = 94, .external_lex_state = 4},
+  [698] = {.lex_state = 94, .external_lex_state = 4},
+  [699] = {.lex_state = 94, .external_lex_state = 4},
+  [700] = {.lex_state = 94, .external_lex_state = 4},
+  [701] = {.lex_state = 94, .external_lex_state = 4},
+  [702] = {.lex_state = 94, .external_lex_state = 4},
   [703] = {.lex_state = 2, .external_lex_state = 7},
   [704] = {.lex_state = 2, .external_lex_state = 7},
   [705] = {.lex_state = 5, .external_lex_state = 4},
-  [706] = {.lex_state = 96, .external_lex_state = 4},
-  [707] = {.lex_state = 96, .external_lex_state = 4},
-  [708] = {.lex_state = 96, .external_lex_state = 4},
-  [709] = {.lex_state = 96, .external_lex_state = 4},
+  [706] = {.lex_state = 94, .external_lex_state = 4},
+  [707] = {.lex_state = 94, .external_lex_state = 4},
+  [708] = {.lex_state = 94, .external_lex_state = 4},
+  [709] = {.lex_state = 94, .external_lex_state = 4},
   [710] = {.lex_state = 2, .external_lex_state = 7},
-  [711] = {.lex_state = 96, .external_lex_state = 4},
+  [711] = {.lex_state = 94, .external_lex_state = 4},
   [712] = {.lex_state = 2, .external_lex_state = 7},
   [713] = {.lex_state = 2, .external_lex_state = 7},
-  [714] = {.lex_state = 96, .external_lex_state = 4},
-  [715] = {.lex_state = 96, .external_lex_state = 4},
+  [714] = {.lex_state = 94, .external_lex_state = 4},
+  [715] = {.lex_state = 94, .external_lex_state = 4},
   [716] = {.lex_state = 2, .external_lex_state = 7},
   [717] = {.lex_state = 2, .external_lex_state = 7},
-  [718] = {.lex_state = 96, .external_lex_state = 4},
+  [718] = {.lex_state = 94, .external_lex_state = 4},
   [719] = {.lex_state = 2, .external_lex_state = 7},
   [720] = {.lex_state = 2, .external_lex_state = 7},
   [721] = {.lex_state = 2, .external_lex_state = 7},
   [722] = {.lex_state = 2, .external_lex_state = 7},
-  [723] = {.lex_state = 96, .external_lex_state = 4},
-  [724] = {.lex_state = 96, .external_lex_state = 4},
+  [723] = {.lex_state = 94, .external_lex_state = 4},
+  [724] = {.lex_state = 94, .external_lex_state = 4},
   [725] = {.lex_state = 2, .external_lex_state = 7},
   [726] = {.lex_state = 2, .external_lex_state = 7},
-  [727] = {.lex_state = 96, .external_lex_state = 4},
+  [727] = {.lex_state = 94, .external_lex_state = 4},
   [728] = {.lex_state = 2, .external_lex_state = 7},
   [729] = {.lex_state = 2, .external_lex_state = 7},
-  [730] = {.lex_state = 96, .external_lex_state = 4},
-  [731] = {.lex_state = 96, .external_lex_state = 4},
-  [732] = {.lex_state = 96, .external_lex_state = 4},
-  [733] = {.lex_state = 96, .external_lex_state = 4},
-  [734] = {.lex_state = 96, .external_lex_state = 4},
+  [730] = {.lex_state = 94, .external_lex_state = 4},
+  [731] = {.lex_state = 94, .external_lex_state = 4},
+  [732] = {.lex_state = 94, .external_lex_state = 4},
+  [733] = {.lex_state = 94, .external_lex_state = 4},
+  [734] = {.lex_state = 94, .external_lex_state = 4},
   [735] = {.lex_state = 4, .external_lex_state = 8},
-  [736] = {.lex_state = 96, .external_lex_state = 4},
-  [737] = {.lex_state = 96, .external_lex_state = 4},
+  [736] = {.lex_state = 94, .external_lex_state = 4},
+  [737] = {.lex_state = 94, .external_lex_state = 4},
   [738] = {.lex_state = 4, .external_lex_state = 8},
-  [739] = {.lex_state = 96, .external_lex_state = 4},
+  [739] = {.lex_state = 94, .external_lex_state = 4},
   [740] = {.lex_state = 4, .external_lex_state = 8},
   [741] = {.lex_state = 4, .external_lex_state = 8},
   [742] = {.lex_state = 5, .external_lex_state = 4},
   [743] = {.lex_state = 4, .external_lex_state = 8},
   [744] = {.lex_state = 4, .external_lex_state = 8},
   [745] = {.lex_state = 4, .external_lex_state = 8},
-  [746] = {.lex_state = 96, .external_lex_state = 4},
+  [746] = {.lex_state = 94, .external_lex_state = 4},
   [747] = {.lex_state = 4, .external_lex_state = 8},
   [748] = {.lex_state = 4, .external_lex_state = 8},
   [749] = {.lex_state = 4, .external_lex_state = 8},
@@ -5958,10 +5930,10 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [751] = {.lex_state = 4, .external_lex_state = 8},
   [752] = {.lex_state = 4, .external_lex_state = 8},
   [753] = {.lex_state = 4, .external_lex_state = 8},
-  [754] = {.lex_state = 96, .external_lex_state = 4},
+  [754] = {.lex_state = 94, .external_lex_state = 4},
   [755] = {.lex_state = 4, .external_lex_state = 8},
-  [756] = {.lex_state = 96, .external_lex_state = 4},
-  [757] = {.lex_state = 96, .external_lex_state = 4},
+  [756] = {.lex_state = 94, .external_lex_state = 4},
+  [757] = {.lex_state = 94, .external_lex_state = 4},
   [758] = {.lex_state = 11, .external_lex_state = 4},
   [759] = {.lex_state = 11, .external_lex_state = 4},
   [760] = {.lex_state = 11, .external_lex_state = 4},
@@ -5985,10 +5957,10 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [778] = {.lex_state = 3, .external_lex_state = 9},
   [779] = {.lex_state = 2, .external_lex_state = 10},
   [780] = {.lex_state = 3, .external_lex_state = 9},
-  [781] = {.lex_state = 96, .external_lex_state = 4},
+  [781] = {.lex_state = 94, .external_lex_state = 4},
   [782] = {.lex_state = 3, .external_lex_state = 9},
   [783] = {.lex_state = 2, .external_lex_state = 10},
-  [784] = {.lex_state = 96, .external_lex_state = 4},
+  [784] = {.lex_state = 94, .external_lex_state = 4},
   [785] = {.lex_state = 2, .external_lex_state = 10},
   [786] = {.lex_state = 3, .external_lex_state = 9},
   [787] = {.lex_state = 3, .external_lex_state = 9},
@@ -6011,8 +5983,8 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [804] = {.lex_state = 2, .external_lex_state = 10},
   [805] = {.lex_state = 2, .external_lex_state = 10},
   [806] = {.lex_state = 3, .external_lex_state = 9},
-  [807] = {.lex_state = 94, .external_lex_state = 4},
-  [808] = {.lex_state = 96, .external_lex_state = 4},
+  [807] = {.lex_state = 92, .external_lex_state = 4},
+  [808] = {.lex_state = 94, .external_lex_state = 4},
   [809] = {.lex_state = 2, .external_lex_state = 10},
   [810] = {.lex_state = 3, .external_lex_state = 9},
   [811] = {.lex_state = 4, .external_lex_state = 11},
@@ -6067,30 +6039,30 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [860] = {.lex_state = 11, .external_lex_state = 6},
   [861] = {.lex_state = 2, .external_lex_state = 7},
   [862] = {.lex_state = 16, .external_lex_state = 4},
-  [863] = {.lex_state = 96, .external_lex_state = 4},
+  [863] = {.lex_state = 94, .external_lex_state = 4},
   [864] = {.lex_state = 2, .external_lex_state = 7},
   [865] = {.lex_state = 2, .external_lex_state = 7},
   [866] = {.lex_state = 16, .external_lex_state = 4},
-  [867] = {.lex_state = 96, .external_lex_state = 4},
+  [867] = {.lex_state = 94, .external_lex_state = 4},
   [868] = {.lex_state = 16, .external_lex_state = 4},
   [869] = {.lex_state = 11, .external_lex_state = 6},
   [870] = {.lex_state = 11, .external_lex_state = 6},
   [871] = {.lex_state = 11, .external_lex_state = 6},
-  [872] = {.lex_state = 96, .external_lex_state = 4},
-  [873] = {.lex_state = 96, .external_lex_state = 4},
+  [872] = {.lex_state = 94, .external_lex_state = 4},
+  [873] = {.lex_state = 94, .external_lex_state = 4},
   [874] = {.lex_state = 16, .external_lex_state = 4},
-  [875] = {.lex_state = 94, .external_lex_state = 5},
-  [876] = {.lex_state = 94, .external_lex_state = 5},
-  [877] = {.lex_state = 94, .external_lex_state = 4},
+  [875] = {.lex_state = 92, .external_lex_state = 5},
+  [876] = {.lex_state = 92, .external_lex_state = 5},
+  [877] = {.lex_state = 92, .external_lex_state = 4},
   [878] = {.lex_state = 4, .external_lex_state = 8},
-  [879] = {.lex_state = 96, .external_lex_state = 4},
+  [879] = {.lex_state = 94, .external_lex_state = 4},
   [880] = {.lex_state = 2, .external_lex_state = 10},
   [881] = {.lex_state = 3, .external_lex_state = 4},
   [882] = {.lex_state = 4, .external_lex_state = 8},
   [883] = {.lex_state = 4, .external_lex_state = 8},
   [884] = {.lex_state = 2, .external_lex_state = 10},
-  [885] = {.lex_state = 96, .external_lex_state = 4},
-  [886] = {.lex_state = 94, .external_lex_state = 4},
+  [885] = {.lex_state = 94, .external_lex_state = 4},
+  [886] = {.lex_state = 92, .external_lex_state = 4},
   [887] = {.lex_state = 3, .external_lex_state = 4},
   [888] = {.lex_state = 3, .external_lex_state = 4},
   [889] = {.lex_state = 3, .external_lex_state = 4},
@@ -6145,7 +6117,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [938] = {.lex_state = 11, .external_lex_state = 4},
   [939] = {.lex_state = 0, .external_lex_state = 4},
   [940] = {.lex_state = 0, .external_lex_state = 4},
-  [941] = {.lex_state = 96, .external_lex_state = 4},
+  [941] = {.lex_state = 94, .external_lex_state = 4},
   [942] = {.lex_state = 11, .external_lex_state = 4},
   [943] = {.lex_state = 0, .external_lex_state = 4},
   [944] = {.lex_state = 0, .external_lex_state = 4},
@@ -6153,9 +6125,9 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [946] = {.lex_state = 0, .external_lex_state = 4},
   [947] = {.lex_state = 0, .external_lex_state = 4},
   [948] = {.lex_state = 3, .external_lex_state = 4},
-  [949] = {.lex_state = 94, .external_lex_state = 5},
+  [949] = {.lex_state = 92, .external_lex_state = 5},
   [950] = {.lex_state = 0, .external_lex_state = 4},
-  [951] = {.lex_state = 94, .external_lex_state = 5},
+  [951] = {.lex_state = 92, .external_lex_state = 5},
   [952] = {.lex_state = 0, .external_lex_state = 4},
   [953] = {.lex_state = 11, .external_lex_state = 4},
   [954] = {.lex_state = 11, .external_lex_state = 4},
@@ -6171,7 +6143,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [964] = {.lex_state = 0, .external_lex_state = 4},
   [965] = {.lex_state = 0, .external_lex_state = 4},
   [966] = {.lex_state = 0, .external_lex_state = 4},
-  [967] = {.lex_state = 96, .external_lex_state = 4},
+  [967] = {.lex_state = 94, .external_lex_state = 4},
   [968] = {.lex_state = 3, .external_lex_state = 4},
   [969] = {.lex_state = 0, .external_lex_state = 4},
   [970] = {.lex_state = 0, .external_lex_state = 4},
@@ -6188,14 +6160,14 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [981] = {.lex_state = 3, .external_lex_state = 4},
   [982] = {.lex_state = 0, .external_lex_state = 6},
   [983] = {.lex_state = 0, .external_lex_state = 4},
-  [984] = {.lex_state = 96, .external_lex_state = 4},
+  [984] = {.lex_state = 94, .external_lex_state = 4},
   [985] = {.lex_state = 0, .external_lex_state = 4},
   [986] = {.lex_state = 20, .external_lex_state = 4},
   [987] = {.lex_state = 0, .external_lex_state = 4},
-  [988] = {.lex_state = 94, .external_lex_state = 5},
-  [989] = {.lex_state = 94, .external_lex_state = 5},
-  [990] = {.lex_state = 94, .external_lex_state = 5},
-  [991] = {.lex_state = 96, .external_lex_state = 4},
+  [988] = {.lex_state = 92, .external_lex_state = 5},
+  [989] = {.lex_state = 92, .external_lex_state = 5},
+  [990] = {.lex_state = 92, .external_lex_state = 5},
+  [991] = {.lex_state = 94, .external_lex_state = 4},
   [992] = {.lex_state = 0, .external_lex_state = 4},
   [993] = {.lex_state = 0, .external_lex_state = 4},
   [994] = {.lex_state = 20, .external_lex_state = 4},
@@ -6221,7 +6193,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1014] = {.lex_state = 20, .external_lex_state = 4},
   [1015] = {.lex_state = 0, .external_lex_state = 6},
   [1016] = {.lex_state = 0, .external_lex_state = 4},
-  [1017] = {.lex_state = 94, .external_lex_state = 5},
+  [1017] = {.lex_state = 92, .external_lex_state = 5},
   [1018] = {.lex_state = 0, .external_lex_state = 4},
   [1019] = {.lex_state = 20, .external_lex_state = 4},
   [1020] = {.lex_state = 20, .external_lex_state = 4},
@@ -6239,24 +6211,24 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1032] = {.lex_state = 20, .external_lex_state = 4},
   [1033] = {.lex_state = 20, .external_lex_state = 4},
   [1034] = {.lex_state = 20, .external_lex_state = 4},
-  [1035] = {.lex_state = 94, .external_lex_state = 5},
+  [1035] = {.lex_state = 92, .external_lex_state = 5},
   [1036] = {.lex_state = 0, .external_lex_state = 4},
-  [1037] = {.lex_state = 96, .external_lex_state = 4},
-  [1038] = {.lex_state = 94, .external_lex_state = 5},
-  [1039] = {.lex_state = 94, .external_lex_state = 5},
+  [1037] = {.lex_state = 94, .external_lex_state = 4},
+  [1038] = {.lex_state = 92, .external_lex_state = 5},
+  [1039] = {.lex_state = 92, .external_lex_state = 5},
   [1040] = {.lex_state = 0, .external_lex_state = 4},
   [1041] = {.lex_state = 11, .external_lex_state = 4},
   [1042] = {.lex_state = 0, .external_lex_state = 4},
   [1043] = {.lex_state = 0, .external_lex_state = 4},
-  [1044] = {.lex_state = 94, .external_lex_state = 4},
+  [1044] = {.lex_state = 92, .external_lex_state = 4},
   [1045] = {.lex_state = 0, .external_lex_state = 4},
   [1046] = {.lex_state = 0, .external_lex_state = 4},
   [1047] = {.lex_state = 0, .external_lex_state = 4},
   [1048] = {.lex_state = 0, .external_lex_state = 4},
   [1049] = {.lex_state = 11, .external_lex_state = 4},
-  [1050] = {.lex_state = 96, .external_lex_state = 4},
+  [1050] = {.lex_state = 94, .external_lex_state = 4},
   [1051] = {.lex_state = 0, .external_lex_state = 4},
-  [1052] = {.lex_state = 96, .external_lex_state = 4},
+  [1052] = {.lex_state = 94, .external_lex_state = 4},
   [1053] = {.lex_state = 0, .external_lex_state = 4},
   [1054] = {.lex_state = 0, .external_lex_state = 4},
   [1055] = {.lex_state = 0, .external_lex_state = 4},
@@ -6268,7 +6240,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1061] = {.lex_state = 11, .external_lex_state = 4},
   [1062] = {.lex_state = 11, .external_lex_state = 4},
   [1063] = {.lex_state = 11, .external_lex_state = 4},
-  [1064] = {.lex_state = 96, .external_lex_state = 4},
+  [1064] = {.lex_state = 94, .external_lex_state = 4},
   [1065] = {.lex_state = 11, .external_lex_state = 4},
   [1066] = {.lex_state = 0, .external_lex_state = 4},
   [1067] = {.lex_state = 11, .external_lex_state = 4},
@@ -6284,17 +6256,17 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1077] = {.lex_state = 0, .external_lex_state = 4},
   [1078] = {.lex_state = 0, .external_lex_state = 4},
   [1079] = {.lex_state = 0, .external_lex_state = 4},
-  [1080] = {.lex_state = 96, .external_lex_state = 4},
+  [1080] = {.lex_state = 94, .external_lex_state = 4},
   [1081] = {.lex_state = 11, .external_lex_state = 4},
   [1082] = {.lex_state = 0, .external_lex_state = 4},
-  [1083] = {.lex_state = 94, .external_lex_state = 4},
-  [1084] = {.lex_state = 94, .external_lex_state = 4},
-  [1085] = {.lex_state = 94, .external_lex_state = 4},
-  [1086] = {.lex_state = 94, .external_lex_state = 4},
-  [1087] = {.lex_state = 94, .external_lex_state = 4},
-  [1088] = {.lex_state = 94, .external_lex_state = 4},
+  [1083] = {.lex_state = 92, .external_lex_state = 4},
+  [1084] = {.lex_state = 92, .external_lex_state = 4},
+  [1085] = {.lex_state = 92, .external_lex_state = 4},
+  [1086] = {.lex_state = 92, .external_lex_state = 4},
+  [1087] = {.lex_state = 92, .external_lex_state = 4},
+  [1088] = {.lex_state = 92, .external_lex_state = 4},
   [1089] = {.lex_state = 0, .external_lex_state = 4},
-  [1090] = {.lex_state = 96, .external_lex_state = 4},
+  [1090] = {.lex_state = 94, .external_lex_state = 4},
   [1091] = {.lex_state = 0, .external_lex_state = 5},
   [1092] = {.lex_state = 0, .external_lex_state = 4},
   [1093] = {.lex_state = 0, .external_lex_state = 4},
@@ -6303,12 +6275,12 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1096] = {.lex_state = 3, .external_lex_state = 4},
   [1097] = {.lex_state = 3, .external_lex_state = 4},
   [1098] = {.lex_state = 6, .external_lex_state = 4},
-  [1099] = {.lex_state = 96, .external_lex_state = 4},
+  [1099] = {.lex_state = 94, .external_lex_state = 4},
   [1100] = {.lex_state = 0, .external_lex_state = 5},
   [1101] = {.lex_state = 0, .external_lex_state = 4},
   [1102] = {.lex_state = 0, .external_lex_state = 4},
   [1103] = {.lex_state = 0, .external_lex_state = 4},
-  [1104] = {.lex_state = 96, .external_lex_state = 4},
+  [1104] = {.lex_state = 94, .external_lex_state = 4},
   [1105] = {.lex_state = 0, .external_lex_state = 4},
   [1106] = {.lex_state = 3, .external_lex_state = 4},
   [1107] = {.lex_state = 6, .external_lex_state = 4},
@@ -6334,7 +6306,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1127] = {.lex_state = 0, .external_lex_state = 4},
   [1128] = {.lex_state = 0, .external_lex_state = 4},
   [1129] = {.lex_state = 0, .external_lex_state = 4},
-  [1130] = {.lex_state = 96, .external_lex_state = 4},
+  [1130] = {.lex_state = 94, .external_lex_state = 4},
   [1131] = {.lex_state = 3, .external_lex_state = 4},
   [1132] = {.lex_state = 0, .external_lex_state = 4},
   [1133] = {.lex_state = 0, .external_lex_state = 4},
@@ -6352,7 +6324,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1145] = {.lex_state = 0, .external_lex_state = 4},
   [1146] = {.lex_state = 3, .external_lex_state = 4},
   [1147] = {.lex_state = 3, .external_lex_state = 4},
-  [1148] = {.lex_state = 96, .external_lex_state = 4},
+  [1148] = {.lex_state = 94, .external_lex_state = 4},
   [1149] = {.lex_state = 3, .external_lex_state = 4},
   [1150] = {.lex_state = 3, .external_lex_state = 4},
   [1151] = {.lex_state = 11, .external_lex_state = 4},
@@ -6369,7 +6341,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1162] = {.lex_state = 11, .external_lex_state = 4},
   [1163] = {.lex_state = 0, .external_lex_state = 4},
   [1164] = {.lex_state = 3, .external_lex_state = 4},
-  [1165] = {.lex_state = 96, .external_lex_state = 4},
+  [1165] = {.lex_state = 94, .external_lex_state = 4},
   [1166] = {.lex_state = 9, .external_lex_state = 4},
   [1167] = {.lex_state = 0, .external_lex_state = 4},
   [1168] = {.lex_state = 3, .external_lex_state = 4},
@@ -6387,7 +6359,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1180] = {.lex_state = 0, .external_lex_state = 4},
   [1181] = {.lex_state = 0, .external_lex_state = 4},
   [1182] = {.lex_state = 3, .external_lex_state = 4},
-  [1183] = {.lex_state = 96, .external_lex_state = 4},
+  [1183] = {.lex_state = 94, .external_lex_state = 4},
   [1184] = {.lex_state = 9, .external_lex_state = 4},
   [1185] = {.lex_state = 3, .external_lex_state = 4},
   [1186] = {.lex_state = 11, .external_lex_state = 4},
@@ -6411,7 +6383,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1204] = {.lex_state = 0, .external_lex_state = 4},
   [1205] = {.lex_state = 0, .external_lex_state = 4},
   [1206] = {.lex_state = 11, .external_lex_state = 4},
-  [1207] = {.lex_state = 96, .external_lex_state = 4},
+  [1207] = {.lex_state = 94, .external_lex_state = 4},
   [1208] = {.lex_state = 11, .external_lex_state = 4},
   [1209] = {.lex_state = 11, .external_lex_state = 4},
   [1210] = {.lex_state = 0, .external_lex_state = 4},
@@ -6456,15 +6428,15 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [1249] = {.lex_state = 11, .external_lex_state = 4},
   [1250] = {.lex_state = 11, .external_lex_state = 4},
   [1251] = {.lex_state = 0, .external_lex_state = 4},
-  [1252] = {.lex_state = 96, .external_lex_state = 4},
+  [1252] = {.lex_state = 94, .external_lex_state = 4},
   [1253] = {.lex_state = 0, .external_lex_state = 4},
-  [1254] = {.lex_state = 96, .external_lex_state = 4},
+  [1254] = {.lex_state = 94, .external_lex_state = 4},
   [1255] = {.lex_state = 0, .external_lex_state = 4},
-  [1256] = {.lex_state = 96, .external_lex_state = 4},
-  [1257] = {.lex_state = 96, .external_lex_state = 4},
-  [1258] = {.lex_state = 96, .external_lex_state = 4},
+  [1256] = {.lex_state = 94, .external_lex_state = 4},
+  [1257] = {.lex_state = 94, .external_lex_state = 4},
+  [1258] = {.lex_state = 94, .external_lex_state = 4},
   [1259] = {.lex_state = 0, .external_lex_state = 5},
-  [1260] = {.lex_state = 96, .external_lex_state = 4},
+  [1260] = {.lex_state = 94, .external_lex_state = 4},
   [1261] = {.lex_state = 3, .external_lex_state = 4},
   [1262] = {.lex_state = 0, .external_lex_state = 4},
   [1263] = {.lex_state = 0, .external_lex_state = 4},
@@ -52820,7 +52792,7 @@ TS_PUBLIC const TSLanguage *tree_sitter_nickel(void) {
     .max_reserved_word_set_size = 0,
     .metadata = {
       .major_version = 0,
-      .minor_version = 6,
+      .minor_version = 1,
       .patch_version = 0,
     },
   };


### PR DESCRIPTION
This fixes the issue with the tree-sitter parser I mentioned in https://github.com/nickel-lang/nickel/pull/2643

Looks like `merge` was a keyword in Nickel at some point, and got removed, but never got removed from here.